### PR TITLE
[FEAT] 페이지 라우팅 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,31 @@
 import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+
+// Page
+import Main from './pages/Main';
+import LogIn from './pages/LogIn';
+import LogOut from './pages/LogOut';
+import Analysis from './pages/Analysis';
 
 function App() {
   return (
-    <div>App component!</div>
+    <Routes>
+      
+      {/* Main */}
+      <Route path='/' element={<Main />} />
+
+      {/* User */}
+      <Route path='user'>
+        <Route path='login' element={ <LogIn /> }/>
+        <Route path='logout' element={ <LogOut /> }/>
+      </Route>
+      
+      {/* Img */}
+      <Route path='img'>
+        <Route path='analysis' element={ <Analysis /> }/>
+      </Route>
+
+    </Routes>
   );
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,9 +5,13 @@ import App from './App';
 import store from './store/store';
 import { Provider } from 'react-redux';
 
+import { BrowserRouter } from 'react-router-dom';
+
 ReactDOM.render(
   <Provider store={store}>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </Provider>,
   document.getElementById("root")
 );

--- a/src/pages/Analysis/index.tsx
+++ b/src/pages/Analysis/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+const Analysis = () => {
+
+  return (
+    <div>Analysis Page!</div> 
+  );
+}
+
+export default Analysis;

--- a/src/pages/LogIn/index.tsx
+++ b/src/pages/LogIn/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+const LogIn = () => {
+
+  return (
+    <div>LogIn Page!</div> 
+  );
+}
+
+export default LogIn;

--- a/src/pages/LogOut/index.tsx
+++ b/src/pages/LogOut/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+const LogOut = () => {
+
+  return (
+    <div>LogOut Page!</div> 
+  );
+}
+
+export default LogOut;

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const Main = () => {
+  return (
+    <div>Main Page!</div>
+  )
+}
+
+export default Main;


### PR DESCRIPTION
## feat/-페이지-라우팅-구현 -> main✨

## 요약✏
- react-router-dom을 사용하여 페이지 라우팅 구현

## 구현 내용📝
- user/login, user/logout, /, img/analysis 경로 생성 및 index.tsx 생성
- 
## Screen
<img width="197" alt="스크린샷 2022-08-03 오후 8 50 26" src="https://user-images.githubusercontent.com/87258182/182601030-28dbcb87-8a9b-45d2-b86c-d363be7c4db8.png">
shots🎨

## 관련 이슈🎯
- index 페이지 접근시 main 컴포넌트 나오게 했는데 나중에 auth를 HOC 또는 children으로 감싸서 토큰 유무에 따라 로그인 페이지로 리다이렉션 하게 구현 하면 될 것 같습니다. 