### PR TITLE
[STYLE] login 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^16.11.47",
         "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.11",
+        "@types/styled-components": "^5.1.25",
         "typescript": "^4.7.4"
       }
     },
@@ -3724,6 +3725,17 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "node_modules/@types/styled-components": {
+      "version": "5.1.25",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.25.tgz",
+      "integrity": "sha512-fgwl+0Pa8pdkwXRoVPP9JbqF0Ivo9llnmsm+7TCI330kbPIFd9qv1Lrhr37shf4tnxCOSu+/IgqM7uJXLWZZNQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/hoist-non-react-statics": "*",
+        "@types/react": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.2",
@@ -19108,6 +19120,17 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "@types/styled-components": {
+      "version": "5.1.25",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.25.tgz",
+      "integrity": "sha512-fgwl+0Pa8pdkwXRoVPP9JbqF0Ivo9llnmsm+7TCI330kbPIFd9qv1Lrhr37shf4tnxCOSu+/IgqM7uJXLWZZNQ==",
+      "dev": true,
+      "requires": {
+        "@types/hoist-non-react-statics": "*",
+        "@types/react": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "@types/trusted-types": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^16.11.47",
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",
+    "@types/styled-components": "^5.1.25",
     "typescript": "^4.7.4"
   },
   "scripts": {

--- a/src/components/Login/Footer.tsx
+++ b/src/components/Login/Footer.tsx
@@ -1,0 +1,41 @@
+import styled from "styled-components";
+import { FlexBox } from "../../style/FlexBox.style";
+import { Button } from "../../style/Button.style";
+
+import { useNavigate } from "react-router-dom";
+
+const FooterLayout = styled(FlexBox)`
+  margin-top: 20px;
+
+  font-size: 0.8rem;
+
+  div {
+    margin-right: 8px;
+  }
+
+  button {
+    font-size: 1rem;
+  }
+`;
+const SignUpButton = styled(Button)`
+  color: #0000ffc0;
+`;
+
+const Footer = () => {
+  const navigate = useNavigate();
+
+  const handleSignUpButtonClick = () => {
+    navigate('/user/signup');
+  };
+  return (
+    <FooterLayout>
+      <div>계정이 없으신가요?</div>
+
+      <SignUpButton onClick={ handleSignUpButtonClick }>
+        회원가입
+      </SignUpButton>
+    </FooterLayout>
+  );
+}
+
+export default Footer;

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from 'react';
+
+import { useInput } from "../../hooks/useInput";
+
+import styled from "styled-components";
+import { Button } from '../../style/Button.style'
+
+interface InputProps {
+  value: any;
+  onChange: any;
+}
+
+const Input = styled.input<InputProps>`
+  width: 100%;
+  height: auto;
+
+  margin-bottom: 12px;
+  padding: 13px 12px;
+
+  border: 1px solid #dedede;
+  border-radius: 4px;
+`;
+
+const LogInButton = styled(Button)`
+  width: 100%;
+  padding: 13px 12px;
+
+  border: 1px solid #dedede;
+  border-radius: 4px;
+
+  background: #fff;
+`;
+
+const LoginLayout = styled.div`
+  width: 90%;
+  height: auto;
+`;
+const LoginForm = () => {
+  const [email, handleEmailChange] = useInput('');
+  const [password, handlePasswordChange] = useInput('');
+
+  const emailRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { emailRef.current?.focus() }, []);
+
+  return (
+    <LoginLayout>
+
+      {/* Input: email, password  */}
+      <Input 
+        value={ email }
+        onChange = { handleEmailChange }
+        placeholder='이메일'
+        name='login-email'
+        type='email' 
+        ref = { emailRef }
+        />
+      <Input 
+        value={ password }
+        onChange = { handlePasswordChange }
+        placeholder='비밀번호'
+        name='login-password'
+        type='password' 
+        />
+
+      {/* Login button */}
+      <LogInButton>로그인</LogInButton>
+        
+    </LoginLayout>
+  );
+}
+
+export default LoginForm;

--- a/src/components/Login/Logo.tsx
+++ b/src/components/Login/Logo.tsx
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+
+const LogoLayout = styled.div`
+  margin-bottom: 40px;
+`;
+
+const Logo = () => {
+  return (
+    <LogoLayout >
+      내밥몇칼로리?
+    </LogoLayout>
+  );
+}
+
+export default Logo;

--- a/src/components/common/CenterBox.tsx
+++ b/src/components/common/CenterBox.tsx
@@ -1,0 +1,25 @@
+import { CenterLayout } from '../../style/CenterLayout.style';
+import { FlexBox } from '../../style/FlexBox.style';
+
+interface Props {
+  background?: string;
+  children: string | JSX.Element | JSX.Element[] ;
+
+  width: string;
+  height: string;
+}
+
+const CenterBox = (props: Props) => {
+  return (
+    <CenterLayout background={ props.background }>
+      <FlexBox width={ props.width } height={ props.height }>
+        
+        {/* Component 들어가는 자리 */}
+        { props.children }
+
+      </FlexBox>
+    </CenterLayout>
+  );
+}
+
+export default CenterBox;

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -1,0 +1,11 @@
+import { useState, useCallback } from 'react';
+
+export const useInput =  (initialvalue = '') => {
+  const [value, setValue] = useState(initialvalue);
+
+  const handler = useCallback((e) => {
+    setValue(e.target.value);
+  }, []);
+  
+  return [value, handler, setValue];
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,18 @@
+/*
+  1. Use a more-intuitive box-sizing model.
+*/
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+/*
+  2. Remove default margin
+*/
+* {
+  margin: 0;
+}
+/*
+  3. Allow percentage-based heights in the application
+*/
+html, body {
+  height: 100%;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from './App';
+import './index.css';
 
 import store from './store/store';
 import { Provider } from 'react-redux';

--- a/src/pages/LogIn/index.tsx
+++ b/src/pages/LogIn/index.tsx
@@ -1,9 +1,30 @@
 import React from "react";
 
+// Component
+import CenterBox from "../../components/common/CenterBox";
+import { FlexBox } from "../../style/FlexBox.style";
+import Logo from '../../components/Login/Logo';
+import LoginForm from "../../components/Login/LoginForm";
+import Footer from "../../components/Login/Footer";
+
+
 const LogIn = () => {
 
   return (
-    <div>LogIn Page!</div> 
+    <CenterBox width="350px" height="400px">
+      <FlexBox flexDirection="column">
+        
+        {/* Logo */}
+        <Logo />
+        
+        {/* LoginForm */}
+        <LoginForm />
+        
+        {/* Footer */}
+        <Footer />
+
+      </FlexBox>
+    </CenterBox> 
   );
 }
 

--- a/src/style/Button.style.ts
+++ b/src/style/Button.style.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const Button = styled.button`
+  outline: none;
+  border: none;
+
+  & {
+    cursor: pointer;
+  }
+`;

--- a/src/style/CenterLayout.style.ts
+++ b/src/style/CenterLayout.style.ts
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+
+interface CenterLayoutProps {
+  background?: string;
+}
+
+export const CenterLayout = styled.div<CenterLayoutProps>`
+  position: fixed;
+  top: 0;
+  left: 0;
+  
+  width: 100%;
+  height: 100%;
+  
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  
+  background: ${ ({ background }) => background || 'none' }
+`;

--- a/src/style/FlexBox.style.ts
+++ b/src/style/FlexBox.style.ts
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+
+interface FlexBoxProps {
+  background?: string;
+
+  width?: string;
+  height?: string;
+
+  flexDirection?: string;
+  justifyContent?: string;
+  alignItems?: string;
+}
+
+export const FlexBox = styled.div<FlexBoxProps>`
+  width: ${ props => props.width };
+  height: ${ props => props.height };
+
+  display: flex;
+  flex-direction: ${ props => props.flexDirection || 'row'};
+  justify-content: ${ props => props.justifyContent || 'center' };
+  align-items: ${ props => props.alignItems || 'center'};
+
+  background: ${ props => props.background || '#EEEEEE' }; 
+`;


### PR DESCRIPTION
## feat/login-page -> main✨

## 요약✏
- 로그인 페이지 UI 구현
- styled-components로 공통 컴포넌트 제작

## 구현 내용📝

### 모듈 추가
- styled-components의 ts 사용을 위해 @types/styled-components 모듈 추가

### 공통 컴포넌트 및 reset css 적용
- FlexBox.style.ts: flex를 사용하여 정렬하기 위한 컴포넌트
- CenterLayout.style.ts: 기존 요소 위치에서 벗어나 레이아웃을 잡기 위한 컴포넌트
- CenterBox.tsx: 위의 두 컴포넌트를 조합하여 만든 컴포넌트
- Button.style.ts: 기본 버튼 컴포넌트
- index.css: reset css 추가

### Login.tsx 하위 컴포넌트
- Logo.tsx: 로고 넣는 컴포넌트
- LoginForm.tsx: 로그인 입력 받는 컴포넌트
- Footer.tsx: 하단에 넣을 기능들을 담는 컴포넌트

## Screenshots🎨
<img width="80%" alt="스크린샷 2022-08-07 오후 6 47 28" src="https://user-images.githubusercontent.com/87258182/183285283-e0341241-a0f8-4541-abc3-eeddbca679f1.png">

## 관련 이슈🎯
- 타입 모르겠는거 any로 일단 썼습니다..
- components폴더에도 해당 페이지의 폴더를 만들었습니다. ex)components/Login
- src/style 폴더에 공통으로 사용할만한 컴포넌트를 각각 파일을 제작하여 넣었는데 한 폴더에 넣을지 아니면 이대로 유지할지 의논 해봐야할것 같습니다.
- 컴포넌트 타입 분리와 스타일드 컴포넌트 타입 관리 어떻게 할 지 의논해봐야할것 같습니다. 