### PR TITLE
[STYLE] main 페이지 레이아웃 구현

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/MyMealCalorie.iml
+++ b/.idea/MyMealCalorie.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/MyMealCalorie.iml" filepath="$PROJECT_DIR$/.idea/MyMealCalorie.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/components/Main/Calendar.tsx
+++ b/src/components/Main/Calendar.tsx
@@ -1,0 +1,7 @@
+const Calendar = () => {
+  return (
+    <div>Calendar</div>
+  )
+}
+
+export default Calendar;

--- a/src/components/Main/Chart.tsx
+++ b/src/components/Main/Chart.tsx
@@ -1,0 +1,7 @@
+const Chart = () => {
+  return (
+    <div>Chart</div>
+  )
+}
+
+export default Chart;

--- a/src/components/Main/SelectedDate.tsx
+++ b/src/components/Main/SelectedDate.tsx
@@ -1,0 +1,7 @@
+const SelectedDate = () => {
+  return (
+    <div>Selected Date's data</div>
+  )
+}
+
+export default SelectedDate;

--- a/src/components/Main/Today.tsx
+++ b/src/components/Main/Today.tsx
@@ -1,0 +1,7 @@
+const Today = () => {
+  return (
+    <div>Today's data</div>
+  )
+}
+
+export default Today;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+import { FlexBox } from "../../style/FlexBox.style";
+
+const Header = () => {
+  return (
+    <S_Wrapper>
+      <p>내밥몇칼로리?</p>  {/*로고*/}
+      <button>Login</button>  {/*로그인*/}
+    </S_Wrapper>
+  )
+}
+
+export default Header;
+
+const S_Wrapper = styled(FlexBox)`
+  justify-content: space-between;
+  height: 64px;
+  padding: 0 50px;
+`

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -7,28 +7,34 @@ import Chart from "../../components/Main/Chart";
 import Today from "../../components/Main/Today";
 import Calendar from "../../components/Main/Calendar";
 import SelectedDate from "../../components/Main/SelectedDate";
+import Header from "../../components/common/Header";
+import { S_Footer } from "../../style/Footer.style";
 
 const Main = () => {
   return (
-    <S_MainLayout>
-      <S_Box>
-        {/* chart */}
-        <Chart />
+    <div>
+      <Header />
+      <S_MainLayout>
+        <S_Box>
+          {/* chart */}
+          <Chart />
 
-        {/* today's data */}
-        <Today />
-      </S_Box>
+          {/* today's data */}
+          <Today />
+        </S_Box>
 
-      <S_BottomTitle>하단 컨테이너 제목</S_BottomTitle>
+        <S_BottomTitle>하단 컨테이너 제목</S_BottomTitle>
 
-      <S_Box>
-        {/* calendar */}
-        <Calendar />
+        <S_Box>
+          {/* calendar */}
+          <Calendar />
 
-        {/* selected date's data */}
-        <SelectedDate />
-      </S_Box>
-    </S_MainLayout>
+          {/* selected date's data */}
+          <SelectedDate />
+        </S_Box>
+      </S_MainLayout>
+      <S_Footer />
+    </div>
   )
 }
 

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,9 +1,55 @@
 import React from "react";
+import styled from "styled-components";
+
+// Component
+import {FlexBox} from "../../style/FlexBox.style";
+import Chart from "../../components/Main/Chart";
+import Today from "../../components/Main/Today";
+import Calendar from "../../components/Main/Calendar";
+import SelectedDate from "../../components/Main/SelectedDate";
 
 const Main = () => {
   return (
-    <div>Main Page!</div>
+    <S_MainLayout>
+      <S_Box>
+        {/* chart */}
+        <Chart />
+
+        {/* today's data */}
+        <Today />
+      </S_Box>
+
+      <S_BottomTitle>하단 컨테이너 제목</S_BottomTitle>
+
+      <S_Box>
+        {/* calendar */}
+        <Calendar />
+
+        {/* selected date's data */}
+        <SelectedDate />
+      </S_Box>
+    </S_MainLayout>
   )
 }
 
 export default Main;
+
+const S_MainLayout = styled(FlexBox)`
+  flex-direction: column;
+  margin: 5%;
+`
+
+const S_Box = styled(FlexBox)`
+  width: 100%;
+  justify-content: space-evenly;
+  margin: 2% 0;
+  padding: 3%;
+`
+
+const S_BottomTitle = styled.p`
+  font-size: large;
+  margin-top: 3%;
+  text-align: center;
+  width: 100%;
+  border-top: 1px solid;  // 임시
+`

--- a/src/style/Footer.style.ts
+++ b/src/style/Footer.style.ts
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const S_Footer = styled.div`
+  height: 150px;
+`


### PR DESCRIPTION
## style/main-layout -> main (Closes #6 )✨

## 요약✏
- main 페이지 전체 레이아웃

## 구현 내용📝
- 컴포넌트 구역 구분 : 전체 flex 내에서 (상단 flex) Chart.tsx / Today.tsx (하단 flex) Calendar.tsx / SelectedDate.tsx
- 공통 Header, Footer 컴포넌트 생성

## Screenshots🎨
<img width="500" alt="image" src="https://user-images.githubusercontent.com/78535339/183348180-76ae876f-ddce-4408-9de3-9dc7722b4e66.png">


## 관련 이슈🎯
- 컴포넌트의 회색 배경 색상 삭제 예정
- Header 로고 나중에 삽입 예정
- Header 로그인 버튼 기능x
