### PR TITLE
[STYLE/CHORE] 식사데이터 디테일 모달창 추가, OneMeal props 타입 변경

### DIFF
--- a/src/components/Main/OneDayList.tsx
+++ b/src/components/Main/OneDayList.tsx
@@ -1,21 +1,26 @@
-import {useState} from "react";
-import styled from "styled-components";
+import { useState } from 'react';
+import styled from 'styled-components';
 
 // Component
-import { S_FlexBox } from "../../style/FlexBox.style";
-import OneMeal from "../common/OneMeal";
+import { S_FlexBox } from '../../style/FlexBox.style';
+import OneMeal from '../common/OneMeal';
 
 const OneDayList = () => {
-
   const [date, setDate] = useState('2022/08/08'); // date 어떤 타입으로?
 
   const [totalCalorie, setTotalCalorie] = useState(2000);
 
-  const [oneDayData, setOneDayData] = useState([  // key값 변경
-    {time: "아침", imgUrl: "https://cdn.imweb.me/upload/S20200615b0849c262a5bf/d91910c88d19f.jpg", calorie: 400},
-    {time: "점심", imgUrl: "img", calorie: 300},
-    {time: "저녁", imgUrl: "img", calorie: 500},
-    {time: "기타", imgUrl: "img", calorie: 600}
+  const [oneDayData, setOneDayData] = useState([
+    // key값 변경
+    {
+      time: '아침',
+      imgUrl:
+        'https://cdn.imweb.me/upload/S20200615b0849c262a5bf/d91910c88d19f.jpg',
+      calorie: 400,
+    },
+    { time: '점심', imgUrl: 'img', calorie: 300 },
+    { time: '저녁', imgUrl: 'img', calorie: 500 },
+    { time: '기타', imgUrl: 'img', calorie: 600 },
   ]);
 
   return (
@@ -25,13 +30,20 @@ const OneDayList = () => {
       </S_DateWrapper>
       <S_Total>총 {totalCalorie}kcal</S_Total>
       <S_Content>
-        {oneDayData.map((oneday) => { // key prop 필요
-          return <OneMeal time={oneday.time} imgUrl={oneday.imgUrl} calorie={oneday.calorie}/>
+        {oneDayData.map(oneday => {
+          // key prop 필요
+          return (
+            <OneMeal
+              time={oneday.time}
+              imgUrl={oneday.imgUrl}
+              calorie={oneday.calorie}
+            />
+          );
         })}
       </S_Content>
     </S_Wrapper>
-  )
-}
+  );
+};
 
 export default OneDayList;
 
@@ -41,17 +53,17 @@ const S_Wrapper = styled(S_FlexBox)`
   border: 1px solid;
   width: 300px;
   height: 450px;
-`
+`;
 
 const S_DateWrapper = styled.div`
   align-self: flex-start;
   padding: 0 20px;
-`
+`;
 
 const S_Total = styled.p`
   font-weight: bold;
-`
+`;
 
 const S_Content = styled.div`
   width: 90%;
-`
+`;

--- a/src/components/Main/OneDayList.tsx
+++ b/src/components/Main/OneDayList.tsx
@@ -12,6 +12,7 @@ const OneDayList = () => {
 
   const [oneDayData, setOneDayData] = useState([
     // key값 변경
+    // data 항목 더 추가될 예정
     {
       time: '아침',
       imgUrl:
@@ -30,15 +31,9 @@ const OneDayList = () => {
       </S_DateWrapper>
       <S_Total>총 {totalCalorie}kcal</S_Total>
       <S_Content>
-        {oneDayData.map(oneday => {
+        {oneDayData.map(data => {
           // key prop 필요
-          return (
-            <OneMeal
-              time={oneday.time}
-              imgUrl={oneday.imgUrl}
-              calorie={oneday.calorie}
-            />
-          );
+          return <OneMeal data={data} />;
         })}
       </S_Content>
     </S_Wrapper>

--- a/src/components/common/OneMeal.tsx
+++ b/src/components/common/OneMeal.tsx
@@ -1,22 +1,40 @@
-import styled from "styled-components";
+import { useState } from 'react';
+import styled from 'styled-components';
 
 // Component
-import { S_FlexBox } from "../../style/FlexBox.style";
+import { S_FlexBox } from '../../style/FlexBox.style';
+import OneMealDetailModal from './OneMealDetailModal';
 
 interface Props {
-  time: string,
-  imgUrl: string,
-  calorie: number
+  time: string;
+  imgUrl: string;
+  calorie: number;
 }
 
-const OneMeal = ({time, imgUrl, calorie}: Props) => {
+const OneMeal = ({ time, imgUrl, calorie }: Props) => {
+  const [showDetailModal, setShowDetailModal] = useState(false);
+
+  const onClickCloseModal = () => {
+    setShowDetailModal(prev => !prev);
+  };
+
+  const onClickShowDetailModal = () => {
+    setShowDetailModal(prev => !prev);
+  };
+
   return (
-    <S_Wrapper>
-      <p>{time}</p>
-      <S_Img src={imgUrl} />
-      <p>{calorie}kcal</p>
-    </S_Wrapper>
-  )
+    <div>
+      <OneMealDetailModal
+        show={showDetailModal}
+        onClickCloseModal={onClickCloseModal}
+      />
+      <S_Wrapper onClick={onClickShowDetailModal}>
+        <p>{time}</p>
+        <S_Img src={imgUrl} />
+        <p>{calorie}kcal</p>
+      </S_Wrapper>
+    </div>
+  );
 };
 
 export default OneMeal;
@@ -26,6 +44,7 @@ const S_Wrapper = styled(S_FlexBox)`
   height: 50px;
   margin: 20px 0;
   justify-content: space-evenly;
+  cursor: pointer;
 `;
 
 const S_Img = styled.img`

--- a/src/components/common/OneMeal.tsx
+++ b/src/components/common/OneMeal.tsx
@@ -6,12 +6,14 @@ import { S_FlexBox } from '../../style/FlexBox.style';
 import OneMealDetailModal from './OneMealDetailModal';
 
 interface Props {
-  time: string;
-  imgUrl: string;
-  calorie: number;
+  data: {
+    time: string;
+    imgUrl: string;
+    calorie: number;
+  };
 }
 
-const OneMeal = ({ time, imgUrl, calorie }: Props) => {
+const OneMeal = ({ data }: Props) => {
   const [showDetailModal, setShowDetailModal] = useState(false);
 
   const onClickCloseModal = () => {
@@ -29,9 +31,9 @@ const OneMeal = ({ time, imgUrl, calorie }: Props) => {
         onClickCloseModal={onClickCloseModal}
       />
       <S_Wrapper onClick={onClickShowDetailModal}>
-        <p>{time}</p>
-        <S_Img src={imgUrl} />
-        <p>{calorie}kcal</p>
+        <p>{data.time}</p>
+        <S_Img src={data.imgUrl} />
+        <p>{data.calorie}kcal</p>
       </S_Wrapper>
     </div>
   );

--- a/src/components/common/OneMealDetailModal.tsx
+++ b/src/components/common/OneMealDetailModal.tsx
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+
+// Component
+import S_CenterBox from '../../style/CenterBox.style';
+import { S_Button } from '../../style/Button.style';
+import { S_FlexBox } from '../../style/FlexBox.style';
+
+interface Props {
+  show: boolean;
+  onClickCloseModal: () => void;
+}
+
+const OneMealDetailModal = ({ show, onClickCloseModal }: Props) => {
+  if (!show) return null;
+
+  return (
+    <S_CenterBox
+      width="300px"
+      height="300px"
+      innerBackgroundColor="white"
+      outerBackgroundColor="rgba(238,238,238,0.8)" // 변경 가능
+    >
+      <S_Wrapper>
+        <S_CloseBtn onClick={onClickCloseModal}>&times;</S_CloseBtn>
+      </S_Wrapper>
+    </S_CenterBox>
+  );
+};
+export default OneMealDetailModal;
+
+const S_Wrapper = styled(S_FlexBox)`
+  flex-direction: column;
+  border: 1px solid;
+  width: 100%;
+  height: 100%;
+`;
+
+const S_CloseBtn = styled(S_Button)`
+  align-self: flex-end;
+`;


### PR DESCRIPTION
## style/onemeal-detail-modal -> main✨

## 요약✏
- 식사데이터 디테일 모달창 구현

## 구현 내용📝
- 식사데이터 디테일 모달창 추가(빈 모달창, 내용x)
- OneMeal props 타입을 상세 데이터 하나씩 받아오는 것에서 전체 데이터 통째로 받아오는 것으로 변경 -> 디테일 모달창으로 데이터 통째로 넘길 예정

## Screenshots🎨

## 관련 이슈🎯
- prettier 적용
- 식사데이터 항목 추가될 예정
- 모달창의 outerbackgroundcolor 변경 가능
