### PR TITLE
[STYLE/REFACTOR] 식사데이터 모달창 구현, 하루데이터 리스트 컴포넌트 분리

### DIFF
--- a/src/components/Main/OneDayList.tsx
+++ b/src/components/Main/OneDayList.tsx
@@ -18,10 +18,42 @@ const OneDayList = () => {
       imgUrl:
         'https://cdn.imweb.me/upload/S20200615b0849c262a5bf/d91910c88d19f.jpg',
       calorie: 400,
+      detail: [
+        { name: '밥', calorie: 300 },
+        { name: '국', calorie: 250 },
+        { name: '김치', calorie: 150 },
+      ],
     },
-    { time: '점심', imgUrl: 'img', calorie: 300 },
-    { time: '저녁', imgUrl: 'img', calorie: 500 },
-    { time: '기타', imgUrl: 'img', calorie: 600 },
+    {
+      time: '점심',
+      imgUrl: 'img',
+      calorie: 300,
+      detail: [
+        { name: '', calorie: 0 },
+        { name: '', calorie: 0 },
+        { name: '', calorie: 0 },
+      ],
+    },
+    {
+      time: '저녁',
+      imgUrl: 'img',
+      calorie: 500,
+      detail: [
+        { name: '', calorie: 0 },
+        { name: '', calorie: 0 },
+        { name: '', calorie: 0 },
+      ],
+    },
+    {
+      time: '기타',
+      imgUrl: 'img',
+      calorie: 600,
+      detail: [
+        { name: '', calorie: 0 },
+        { name: '', calorie: 0 },
+        { name: '', calorie: 0 },
+      ],
+    },
   ]);
 
   return (

--- a/src/components/Main/OneDayListContainer.tsx
+++ b/src/components/Main/OneDayListContainer.tsx
@@ -4,8 +4,9 @@ import styled from 'styled-components';
 // Component
 import { S_FlexBox } from '../../style/FlexBox.style';
 import OneMeal from '../common/OneMeal';
+import OneDayList from '../common/OneDayList';
 
-const OneDayList = () => {
+const OneDayListContainer = () => {
   const [date, setDate] = useState('2022/08/08'); // date 어떤 타입으로?
 
   const [totalCalorie, setTotalCalorie] = useState(2000);
@@ -62,17 +63,12 @@ const OneDayList = () => {
         <span>{date}</span>
       </S_DateWrapper>
       <S_Total>총 {totalCalorie}kcal</S_Total>
-      <S_Content>
-        {oneDayData.map(data => {
-          // key prop 필요
-          return <OneMeal data={data} />;
-        })}
-      </S_Content>
+      <OneDayList dataList={oneDayData} />
     </S_Wrapper>
   );
 };
 
-export default OneDayList;
+export default OneDayListContainer;
 
 const S_Wrapper = styled(S_FlexBox)`
   flex-direction: column;
@@ -89,8 +85,4 @@ const S_DateWrapper = styled.div`
 
 const S_Total = styled.p`
   font-weight: bold;
-`;
-
-const S_Content = styled.div`
-  width: 90%;
 `;

--- a/src/components/common/OneDayList.tsx
+++ b/src/components/common/OneDayList.tsx
@@ -1,0 +1,30 @@
+import OneMeal from './OneMeal';
+import styled from 'styled-components';
+
+interface Props {
+  dataList: {
+    time: string;
+    imgUrl: string;
+    calorie: number;
+    detail: {
+      name: string;
+      calorie: number;
+    }[];
+  }[];
+}
+
+const OneDayList = ({ dataList }: Props) => {
+  return (
+    <S_Content>
+      {dataList.map(data => {
+        return <OneMeal data={data} />;
+      })}
+    </S_Content>
+  );
+};
+
+export default OneDayList;
+
+const S_Content = styled.div`
+  width: 90%;
+`;

--- a/src/components/common/OneMeal.tsx
+++ b/src/components/common/OneMeal.tsx
@@ -10,6 +10,10 @@ interface Props {
     time: string;
     imgUrl: string;
     calorie: number;
+    detail: {
+      name: string;
+      calorie: number;
+    }[];
   };
 }
 
@@ -29,6 +33,7 @@ const OneMeal = ({ data }: Props) => {
       <OneMealDetailModal
         show={showDetailModal}
         onClickCloseModal={onClickCloseModal}
+        data={data}
       />
       <S_Wrapper onClick={onClickShowDetailModal}>
         <p>{data.time}</p>

--- a/src/components/common/OneMealDetailModal.tsx
+++ b/src/components/common/OneMealDetailModal.tsx
@@ -8,20 +8,47 @@ import { S_FlexBox } from '../../style/FlexBox.style';
 interface Props {
   show: boolean;
   onClickCloseModal: () => void;
+  data: {
+    time: string;
+    imgUrl: string;
+    calorie: number;
+    detail: {
+      name: string;
+      calorie: number;
+    }[];
+  };
 }
 
-const OneMealDetailModal = ({ show, onClickCloseModal }: Props) => {
+const OneMealDetailModal = ({ show, onClickCloseModal, data }: Props) => {
   if (!show) return null;
 
   return (
     <S_CenterBox
-      width="300px"
-      height="300px"
+      width="500px"
+      height="500px"
       innerBackgroundColor="white"
       outerBackgroundColor="rgba(238,238,238,0.8)" // 변경 가능
     >
       <S_Wrapper>
         <S_CloseBtn onClick={onClickCloseModal}>&times;</S_CloseBtn>
+        <S_TimeWrapper>
+          <p>{data.time}</p>
+        </S_TimeWrapper>
+        <S_ContentWrapper>
+          <S_Img src={data.imgUrl} />
+          <S_Content>
+            <p>총 {data.calorie}kcal</p>
+            <S_DetailMap>
+              {data.detail.map(food => {
+                return (
+                  <p>
+                    {food.name}: {food.calorie}kcal
+                  </p>
+                );
+              })}
+            </S_DetailMap>
+          </S_Content>
+        </S_ContentWrapper>
       </S_Wrapper>
     </S_CenterBox>
   );
@@ -30,6 +57,7 @@ export default OneMealDetailModal;
 
 const S_Wrapper = styled(S_FlexBox)`
   flex-direction: column;
+  justify-content: flex-start;
   border: 1px solid;
   width: 100%;
   height: 100%;
@@ -37,4 +65,43 @@ const S_Wrapper = styled(S_FlexBox)`
 
 const S_CloseBtn = styled(S_Button)`
   align-self: flex-end;
+`;
+
+const S_TimeWrapper = styled.div`
+  align-self: flex-start;
+  margin: 5% 10%;
+`;
+
+const S_ContentWrapper = styled(S_FlexBox)`
+  flex-direction: column;
+  justify-content: flex-start;
+  width: 90%;
+  height: 100%;
+`;
+
+const S_Img = styled.img`
+  width: 70%;
+`;
+
+const S_Content = styled(S_FlexBox)`
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  margin: 5% 0;
+  & > p {
+    margin: 2% 0;
+    font-weight: bold;
+  }
+`;
+
+const S_DetailMap = styled(S_FlexBox)`
+  flex-wrap: wrap;
+  width: 100%;
+  height: 100%;
+  // overflow-y: scroll;  - height 지정해야 함
+  overflow-y: scroll;
+  padding: 5px;
+  & > p {
+    margin: 2%;
+  }
 `;

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,14 +1,14 @@
-import React from "react";
-import styled from "styled-components";
+import React from 'react';
+import styled from 'styled-components';
 
 // Component
-import { S_FlexBox } from "../../style/FlexBox.style";
-import Chart from "../../components/Main/Chart";
-import Today from "../../components/Main/Today";
-import Calendar from "../../components/Main/Calendar";
-import OneDayList from "../../components/Main/OneDayList";
-import Header from "../../components/common/Header";
-import { S_Footer } from "../../style/Footer.style";
+import { S_FlexBox } from '../../style/FlexBox.style';
+import Chart from '../../components/Main/Chart';
+import Today from '../../components/Main/Today';
+import Calendar from '../../components/Main/Calendar';
+import OneDayListContainer from '../../components/Main/OneDayListContainer';
+import Header from '../../components/common/Header';
+import { S_Footer } from '../../style/Footer.style';
 
 const Main = () => {
   return (
@@ -30,32 +30,32 @@ const Main = () => {
           <Calendar />
 
           {/* selected date's data */}
-          <OneDayList />
+          <OneDayListContainer />
         </S_Box>
       </S_MainLayout>
       <S_Footer />
     </div>
-  )
-}
+  );
+};
 
 export default Main;
 
 const S_MainLayout = styled(S_FlexBox)`
   flex-direction: column;
   margin: 5%;
-`
+`;
 
 const S_Box = styled(S_FlexBox)`
   width: 100%;
   justify-content: space-evenly;
   margin: 2% 0;
   padding: 3%;
-`
+`;
 
 const S_BottomTitle = styled.p`
   font-size: large;
   margin-top: 3%;
   text-align: center;
   width: 100%;
-  border-top: 1px solid;  // 임시
-`
+  border-top: 1px solid; // 임시
+`;


### PR DESCRIPTION
## style/onemeal-detail-modal -> main (Closes #15 )✨

## 요약✏
- 식사데이터 디테일 UI 구현

## 구현 내용📝
- 식사데이터 모달창 내용 배치 레이아웃
- 하루데이터 리스트를 map 돌리는 컴포넌트 따로 분리 (OneDayList.tsx)

## Screenshots🎨
![image](https://user-images.githubusercontent.com/78535339/183594164-c53a3880-f9c4-4162-8c51-f442961c955e.png)


## 관련 이슈🎯
- prettier 적용
- 상세한 디자인은 추후 변경 가능성
