### PR TITLE
[style] TodayNutrition UI 구현

### DIFF
--- a/src/components/Main/Today.tsx
+++ b/src/components/Main/Today.tsx
@@ -1,7 +1,0 @@
-const Today = () => {
-  return (
-    <div>Today's data</div>
-  )
-}
-
-export default Today;

--- a/src/components/Main/TodayNutrition.tsx
+++ b/src/components/Main/TodayNutrition.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+
+import styled from 'styled-components';
+import { S_FlexBox } from '../../style/FlexBox.style';
+import { S_Button } from '../../style/Button.style';
+
+import OneDayList from '../common/OneDayList';
+
+const TodayNutrition = () => {
+  const [todayDayData, setTodayDayData] = useState([
+    // key값 변경
+    // data 항목 더 추가될 예정
+    {
+      time: '아침',
+      imgUrl:
+        'https://cdn.imweb.me/upload/S20200615b0849c262a5bf/d91910c88d19f.jpg',
+      calorie: 400,
+      detail: [
+        { name: '밥', calorie: 300 },
+        { name: '국', calorie: 250 },
+        { name: '김치', calorie: 150 },
+      ],
+    },
+    {
+      time: '점심',
+      imgUrl: 'img',
+      calorie: 300,
+      detail: [
+        { name: '', calorie: 0 },
+        { name: '', calorie: 0 },
+        { name: '', calorie: 0 },
+      ],
+    },
+    {
+      time: '저녁',
+      imgUrl: 'img',
+      calorie: 500,
+      detail: [
+        { name: '', calorie: 0 },
+        { name: '', calorie: 0 },
+        { name: '', calorie: 0 },
+      ],
+    },
+    {
+      time: '기타',
+      imgUrl: 'img',
+      calorie: 600,
+      detail: [
+        { name: '', calorie: 0 },
+        { name: '', calorie: 0 },
+        { name: '', calorie: 0 },
+      ],
+    },
+  ]);
+  return (
+    <S_Wrapper>
+      {/* Title */}
+      <S_Title>Today</S_Title>
+
+      {/* 오늘 식사 리스트*/}
+      <OneDayList dataList={todayDayData} />
+
+      <S_UploadBtn>+</S_UploadBtn>
+    </S_Wrapper>
+  );
+};
+
+export default TodayNutrition;
+
+const S_Wrapper = styled(S_FlexBox)`
+  flex-direction: column;
+  justify-content: space-evenly;
+  width: 300px;
+  height: 450px;
+
+  border: 1px solid;
+`;
+const S_Title = styled(S_FlexBox)`
+  font-size: 1.3rem;
+  font-weight: 500;
+`;
+const S_UploadBtn = styled(S_Button)`
+  font-size: 1.8rem;
+  font-weight: 500;
+`;

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 // Component
 import { S_FlexBox } from '../../style/FlexBox.style';
 import Chart from '../../components/Main/Chart';
-import Today from '../../components/Main/Today';
+import TodayNutrition from '../../components/Main/TodayNutrition';
 import Calendar from '../../components/Main/Calendar';
 import OneDayListContainer from '../../components/Main/OneDayListContainer';
 import Header from '../../components/common/Header';
@@ -20,7 +20,7 @@ const Main = () => {
           <Chart />
 
           {/* today's data */}
-          <Today />
+          <TodayNutrition />
         </S_Box>
 
         <S_BottomTitle>하단 컨테이너 제목</S_BottomTitle>


### PR DESCRIPTION
## style/today-nutrition -> main (Closes #14)✨

## 요약✏
- main페이지 오른쪽 상단 컴포넌트 구현

## 구현 내용📝
- TodayNutrition 구현
- 기존 구현된 OneDayList 컴포넌트 사용

## Screenshots🎨
<img width="80%" alt="스크린샷 2022-08-09 오후 9 29 11" src="https://user-images.githubusercontent.com/87258182/183647076-3fb88fdd-4da0-4878-a8e7-80aaf2644847.png">

## 관련 이슈🎯
- Today.tsx -> TodayNutrition.tsx로 변경
