### PR TITLE
[STYLE] react-calendar 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@types/node": "^16.11.47",
         "@types/react": "^17.0.39",
+        "@types/react-calendar": "^3.5.2",
         "@types/react-dom": "^17.0.11",
         "@types/styled-components": "^5.1.25",
         "prettier": "^2.7.1",
@@ -3668,6 +3669,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-calendar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/react-calendar/-/react-calendar-3.5.2.tgz",
+      "integrity": "sha512-8gkU9KaE33VVbu3YWvxXjEk4BsalgSYR3c/5XF9XNJiQ/2MKxiGkTg/PfOHUX/BvcADykRBMAEJiCi6jFPEE3A==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-dom": {
@@ -19078,6 +19088,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-calendar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/react-calendar/-/react-calendar-3.5.2.tgz",
+      "integrity": "sha512-8gkU9KaE33VVbu3YWvxXjEk4BsalgSYR3c/5XF9XNJiQ/2MKxiGkTg/PfOHUX/BvcADykRBMAEJiCi6jFPEE3A==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/react-dom": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@types/node": "^16.11.47",
     "@types/react": "^17.0.39",
+    "@types/react-calendar": "^3.5.2",
     "@types/react-dom": "^17.0.11",
     "@types/styled-components": "^5.1.25",
     "prettier": "^2.7.1",

--- a/src/components/Main/Calendar.tsx
+++ b/src/components/Main/Calendar.tsx
@@ -1,7 +1,0 @@
-const Calendar = () => {
-  return (
-    <div>Calendar</div>
-  )
-}
-
-export default Calendar;

--- a/src/components/Main/CalendarContainer.tsx
+++ b/src/components/Main/CalendarContainer.tsx
@@ -1,0 +1,22 @@
+import Calendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+
+interface Props {
+  date: Date;
+  setDate: any;
+}
+
+const CalendarContainer = ({ date, setDate }: Props) => {
+  const onChangeDate = (e: any) => {
+    console.log(e);
+    setDate(e);
+  };
+
+  return (
+    <div>
+      <Calendar value={date} onChange={onChangeDate} />
+    </div>
+  );
+};
+
+export default CalendarContainer;

--- a/src/components/Main/OneDayListContainer.tsx
+++ b/src/components/Main/OneDayListContainer.tsx
@@ -3,12 +3,13 @@ import styled from 'styled-components';
 
 // Component
 import { S_FlexBox } from '../../style/FlexBox.style';
-import OneMeal from '../common/OneMeal';
 import OneDayList from '../common/OneDayList';
 
-const OneDayListContainer = () => {
-  const [date, setDate] = useState('2022/08/08'); // date 어떤 타입으로?
+interface Props {
+  date: Date;
+}
 
+const OneDayListContainer = ({ date }: Props) => {
   const [totalCalorie, setTotalCalorie] = useState(2000);
 
   const [oneDayData, setOneDayData] = useState([
@@ -57,10 +58,16 @@ const OneDayListContainer = () => {
     },
   ]);
 
+  const DateParsing = () => {
+    const list = date.toString().split(' ');
+    // console.log(list);
+    return `${list[3]} / ${list[1]} / ${list[2]} ${list[0]}`;
+  };
+
   return (
     <S_Wrapper>
       <S_DateWrapper>
-        <span>{date}</span>
+        <span>{DateParsing()}</span>
       </S_DateWrapper>
       <S_Total>총 {totalCalorie}kcal</S_Total>
       <OneDayList dataList={oneDayData} />

--- a/src/components/common/OneDayList.tsx
+++ b/src/components/common/OneDayList.tsx
@@ -1,5 +1,7 @@
-import OneMeal from './OneMeal';
 import styled from 'styled-components';
+
+// Component
+import OneMeal from './OneMeal';
 
 interface Props {
   dataList: {

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,16 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 // Component
 import { S_FlexBox } from '../../style/FlexBox.style';
 import Chart from '../../components/Main/Chart';
 import TodayNutrition from '../../components/Main/TodayNutrition';
-import Calendar from '../../components/Main/Calendar';
+import CalendarContainer from '../../components/Main/CalendarContainer';
 import OneDayListContainer from '../../components/Main/OneDayListContainer';
 import Header from '../../components/common/Header';
 import { S_Footer } from '../../style/Footer.style';
 
 const Main = () => {
+  const [date, setDate] = useState(new Date());
+
   return (
     <div>
       <Header />
@@ -27,10 +29,10 @@ const Main = () => {
 
         <S_Box>
           {/* calendar */}
-          <Calendar />
+          <CalendarContainer date={date} setDate={setDate} />
 
           {/* selected date's data */}
-          <OneDayListContainer />
+          <OneDayListContainer date={date} />
         </S_Box>
       </S_MainLayout>
       <S_Footer />


### PR DESCRIPTION
## feat/calendar -> main✨

## 요약✏
- react-calendar 적용

## 구현 내용📝
- react-calendar 라이브러리 설치
- 캘린더에서 날짜 선택시 하루데이터에 해당 날짜 반영

## Screenshots🎨
![image](https://user-images.githubusercontent.com/78535339/183829667-7dca9435-39c2-46e8-abe0-59b61542a97c.png)

## 관련 이슈🎯
- 달력 디자인 커스터마이징 할까요?
- date 상태 main 페이지로 뺌(useState)
- feat/calendar에서 달력의 디자인 및 기능 계속 구현 진행할 예정