### PR TITLE
[STYLE] Analysis 페이지 UI 구현

### DIFF
--- a/src/pages/Analysis/index.tsx
+++ b/src/pages/Analysis/index.tsx
@@ -23,8 +23,7 @@ const Analysis = () => {
     { name: '제육볶음', calorie: 180 },
   ]);
 
-  const [totalCalorie, setTotalcalorie] = useState(595); // 각 칼로리의 합으로 계산하기
-
+  const [totalCalorie, setTotalcalorie] = useState(595); // 각 칼로리의 합으로 계산하기ㄴ_
   const CalorieDetail = () => {
     return (
       <S_CalorieDetailWrapper>
@@ -46,22 +45,28 @@ const Analysis = () => {
   return (
     <div>
       <Header />
-      <S_Box>
-        <S_ImgWrapper>
-          <img src={imgUrl} />
-        </S_ImgWrapper>
-        <S_FlexBox flexDirection="column" width="300px" height="500px">
-          <S_DetailWrapper>
-            <p>칼로리 정보</p>
-            <CalorieDetail />
-            <S_FlexBox justifyContent="space-between" width="70%" height="50px">
-              <p>총 칼로리</p>
-              <p>{totalCalorie}kcal</p>
-            </S_FlexBox>
-          </S_DetailWrapper>
-          <S_SendBtn>저장하기</S_SendBtn>
-        </S_FlexBox>
-      </S_Box>
+      <S_FlexBox>
+        <S_Box>
+          <S_ImgWrapper>
+            <img src={imgUrl} />
+          </S_ImgWrapper>
+          <S_FlexBox flexDirection="column" width="300px" height="500px">
+            <S_DetailWrapper>
+              <p>칼로리 정보</p>
+              <CalorieDetail />
+              <S_FlexBox
+                justifyContent="space-between"
+                width="70%"
+                height="50px"
+              >
+                <p>총 칼로리</p>
+                <p>{totalCalorie}kcal</p>
+              </S_FlexBox>
+            </S_DetailWrapper>
+            <S_SendBtn>저장하기</S_SendBtn>
+          </S_FlexBox>
+        </S_Box>
+      </S_FlexBox>
     </div>
   );
 };

--- a/src/pages/Analysis/index.tsx
+++ b/src/pages/Analysis/index.tsx
@@ -1,10 +1,69 @@
-import React from "react";
+import React, { useState } from 'react';
+import {
+  S_CalorieDetailWrapper,
+  S_DetailWrapper,
+  S_ImgWrapper,
+  S_InputCalorie,
+  S_SendBtn,
+} from './style';
+import Header from '../../components/common/Header';
+import { S_Box } from '../Main/style';
+import { S_FlexBox } from '../../style/FlexBox.style';
 
 const Analysis = () => {
+  const [imgUrl, setImgUrl] = useState(
+    'https://cdn.imweb.me/upload/S20200615b0849c262a5bf/d91910c88d19f.jpg'
+  );
+
+  const [calorieData, setCalorieData] = useState([
+    { name: '쌀밥', calorie: 300 },
+    { name: '오징어국', calorie: 50 },
+    { name: '치킨샐러드', calorie: 40 },
+    { name: '두부', calorie: 25 },
+    { name: '제육볶음', calorie: 180 },
+  ]);
+
+  const [totalCalorie, setTotalcalorie] = useState(595); // 각 칼로리의 합으로 계산하기
+
+  const CalorieDetail = () => {
+    return (
+      <S_CalorieDetailWrapper>
+        {calorieData.map(data => {
+          return (
+            <S_FlexBox justifyContent="space-between" margin="5% 0">
+              <p>{data.name}</p>
+              <div>
+                <S_InputCalorie value={data.calorie} />
+                <span>kcal</span>
+              </div>
+            </S_FlexBox>
+          );
+        })}
+      </S_CalorieDetailWrapper>
+    );
+  };
 
   return (
-    <div>Analysis Page!</div> 
+    <div>
+      <Header />
+      <S_Box>
+        <S_ImgWrapper>
+          <img src={imgUrl} />
+        </S_ImgWrapper>
+        <S_FlexBox flexDirection="column" width="300px" height="500px">
+          <S_DetailWrapper>
+            <p>칼로리 정보</p>
+            <CalorieDetail />
+            <S_FlexBox justifyContent="space-between" width="70%" height="50px">
+              <p>총 칼로리</p>
+              <p>{totalCalorie}kcal</p>
+            </S_FlexBox>
+          </S_DetailWrapper>
+          <S_SendBtn>저장하기</S_SendBtn>
+        </S_FlexBox>
+      </S_Box>
+    </div>
   );
-}
+};
 
 export default Analysis;

--- a/src/pages/Analysis/style.ts
+++ b/src/pages/Analysis/style.ts
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+import { S_FlexBox } from '../../style/FlexBox.style';
+import { S_Button } from '../../style/Button.style';
+
+export const S_ImgWrapper = styled(S_FlexBox)`
+  width: 50%;
+  border: 1px solid;
+  filter: drop-shadow(0 0.3rem 0.4rem rgba(0, 0, 0, 0.5));
+  & > img {
+    width: 100%;
+  }
+`;
+
+export const S_DetailWrapper = styled(S_FlexBox)`
+  flex-direction: column;
+  justify-content: space-between;
+  width: 100%;
+  height: 80%;
+  padding: 30px 0;
+  border: 0.5px rgba(128, 128, 128, 0.39) solid;
+  box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px,
+    rgba(60, 64, 67, 0.15) 0px 1px 3px 1px;
+  //box-shadow: rgba(0, 0, 0, 0.3) 0px 19px 38px,
+  //  rgba(0, 0, 0, 0.22) 0px 15px 12px;
+`;
+
+export const S_CalorieDetailWrapper = styled.div`
+  width: 70%;
+`;
+
+export const S_InputCalorie = styled.input`
+  width: 40px;
+`;
+
+export const S_SendBtn = styled(S_Button)`
+  background-color: #99d156;
+  color: rgba(0, 0, 0, 0.8);
+  font-weight: 500;
+  font-size: large;
+  width: 90%;
+  height: 10%;
+  margin-top: 20px;
+  border-radius: 10px;
+  box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px,
+    rgba(60, 64, 67, 0.15) 0px 1px 3px 1px;
+`;

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+
+// Style
+import { S_BottomTitle, S_Box, S_MainLayout } from './style';
 
 // Component
-import { S_FlexBox } from '../../style/FlexBox.style';
 import Chart from '../../components/Main/Chart';
 import TodayNutrition from '../../components/Main/TodayNutrition';
 import CalendarContainer from '../../components/Main/CalendarContainer';
@@ -41,23 +42,3 @@ const Main = () => {
 };
 
 export default Main;
-
-const S_MainLayout = styled(S_FlexBox)`
-  flex-direction: column;
-  margin: 5%;
-`;
-
-const S_Box = styled(S_FlexBox)`
-  width: 100%;
-  justify-content: space-evenly;
-  margin: 2% 0;
-  padding: 3%;
-`;
-
-const S_BottomTitle = styled.p`
-  font-size: large;
-  margin-top: 3%;
-  text-align: center;
-  width: 100%;
-  border-top: 1px solid; // 임시
-`;

--- a/src/pages/Main/style.ts
+++ b/src/pages/Main/style.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import { S_FlexBox } from '../../style/FlexBox.style';
+
+export const S_MainLayout = styled(S_FlexBox)`
+  flex-direction: column;
+  margin: 5%;
+`;
+
+export const S_Box = styled(S_FlexBox)`
+  width: 100%;
+  justify-content: space-evenly;
+  margin: 2% 0;
+  padding: 3%;
+`;
+
+export const S_BottomTitle = styled.p`
+  font-size: large;
+  margin-top: 3%;
+  text-align: center;
+  width: 100%;
+  border-top: 1px solid; // 임시
+`;

--- a/src/style/FlexBox.style.ts
+++ b/src/style/FlexBox.style.ts
@@ -1,10 +1,11 @@
-import styled from "styled-components";
+import styled from 'styled-components';
 
 interface FlexBoxProps {
   background?: string;
 
   width?: string;
   height?: string;
+  margin?: string;
 
   flexDirection?: string;
   justifyContent?: string;
@@ -12,13 +13,14 @@ interface FlexBoxProps {
 }
 
 export const S_FlexBox = styled.div<FlexBoxProps>`
-  width: ${ props => props.width };
-  height: ${ props => props.height };
+  width: ${props => props.width};
+  height: ${props => props.height};
+  margin: ${props => props.margin};
 
   display: flex;
-  flex-direction: ${ props => props.flexDirection || 'row'};
-  justify-content: ${ props => props.justifyContent || 'center' };
-  align-items: ${ props => props.alignItems || 'center'};
+  flex-direction: ${props => props.flexDirection || 'row'};
+  justify-content: ${props => props.justifyContent || 'center'};
+  align-items: ${props => props.alignItems || 'center'};
 
-  background: ${ props => props.background || 'none' }; 
+  background: ${props => props.background || 'none'};
 `;


### PR DESCRIPTION
## style/analysis-page-UI -> main (Closes #23 )✨

## 요약✏
- 이미지 분석 페이지 UI 구현

## 구현 내용📝
- 전체 배치
- 이미지, 디테일 박스, 저장 버튼에 box-shadow 적용
- 저장 버튼에 색 적용(#99d156)
- main 페이지 style.ts 분리

## Screenshots🎨
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/78535339/184081341-33a2656e-65b9-4dff-a863-7cf2a3ce7967.png">


## 관련 이슈🎯
- 임시 데이터로 테스트
- 입력 및 버튼 기능x
- 데이터 확인(입력) 요청 모달창 구현 예정
