### PR TITLE
[CHORE] stylecomponent folder 구조 변경

### DIFF
--- a/src/components/Login/Footer.tsx
+++ b/src/components/Login/Footer.tsx
@@ -1,25 +1,6 @@
-import styled from "styled-components";
-import { S_FlexBox } from "../../style/FlexBox.style";
-import { S_Button } from "../../style/Button.style";
+import { useNavigate } from 'react-router-dom';
 
-import { useNavigate } from "react-router-dom";
-
-const FooterLayout = styled(S_FlexBox)`
-  margin-top: 20px;
-
-  font-size: 0.8rem;
-
-  div {
-    margin-right: 8px;
-  }
-
-  button {
-    font-size: 1rem;
-  }
-`;
-const SignUpButton = styled(S_Button)`
-  color: #0000ffc0;
-`;
+import { S_FooterWrapper, S_SignUpButton } from './style';
 
 const Footer = () => {
   const navigate = useNavigate();
@@ -28,14 +9,14 @@ const Footer = () => {
     navigate('/user/signup');
   };
   return (
-    <FooterLayout>
+    <S_FooterWrapper>
       <div>계정이 없으신가요?</div>
 
-      <SignUpButton onClick={ handleSignUpButtonClick }>
+      <S_SignUpButton onClick={handleSignUpButtonClick}>
         회원가입
-      </SignUpButton>
-    </FooterLayout>
+      </S_SignUpButton>
+    </S_FooterWrapper>
   );
-}
+};
 
 export default Footer;

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -1,73 +1,42 @@
 import { useEffect, useRef } from 'react';
 
-import { useInput } from "../../hooks/useInput";
+import { useInput } from '../../hooks/useInput';
 
-import styled from "styled-components";
-import { S_Button } from '../../style/Button.style'
+import { S_LoginWrapper, S_Input, S_LogInButton } from './style';
 
-interface InputProps {
-  value: any;
-  onChange: any;
-}
-
-const S_Input = styled.input<InputProps>`
-  width: 100%;
-  height: auto;
-
-  margin-bottom: 12px;
-  padding: 13px 12px;
-
-  border: 1px solid #dedede;
-  border-radius: 4px;
-`;
-
-const S_LogInButton = styled(S_Button)`
-  width: 100%;
-  padding: 13px 12px;
-
-  border: 1px solid #dedede;
-  border-radius: 4px;
-
-  background: #fff;
-`;
-
-const S_LoginLayout = styled.div`
-  width: 90%;
-  height: auto;
-`;
 const LoginForm = () => {
   const [email, onChangeEmail] = useInput('');
   const [password, onChangePassword] = useInput('');
 
   const emailRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => { emailRef.current?.focus() }, []);
+  useEffect(() => {
+    emailRef.current?.focus();
+  }, []);
 
   return (
-    <S_LoginLayout>
-
+    <S_LoginWrapper>
       {/* Input: email, password  */}
-      <S_Input 
-        value={ email }
-        onChange = { onChangeEmail }
-        placeholder='이메일'
-        name='login-email'
-        type='email' 
-        ref = { emailRef }
-        />
-      <S_Input 
-        value={ password }
-        onChange = { onChangePassword }
-        placeholder='비밀번호'
-        name='login-password'
-        type='password' 
-        />
+      <S_Input
+        value={email}
+        onChange={onChangeEmail}
+        placeholder="이메일"
+        name="login-email"
+        type="email"
+        ref={emailRef}
+      />
+      <S_Input
+        value={password}
+        onChange={onChangePassword}
+        placeholder="비밀번호"
+        name="login-password"
+        type="password"
+      />
 
       {/* Login button */}
       <S_LogInButton>로그인</S_LogInButton>
-        
-    </S_LoginLayout>
+    </S_LoginWrapper>
   );
-}
+};
 
 export default LoginForm;

--- a/src/components/Login/Logo.tsx
+++ b/src/components/Login/Logo.tsx
@@ -1,15 +1,7 @@
-import styled from "styled-components";
-
-const LogoLayout = styled.div`
-  margin-bottom: 40px;
-`;
+import { LogoWrapper } from './style';
 
 const Logo = () => {
-  return (
-    <LogoLayout >
-      내밥몇칼로리?
-    </LogoLayout>
-  );
-}
+  return <LogoWrapper>내밥몇칼로리?</LogoWrapper>;
+};
 
 export default Logo;

--- a/src/components/Login/style/index.ts
+++ b/src/components/Login/style/index.ts
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+import { S_FlexBox } from '../../../style/FlexBox.style';
+import { S_Button } from '../../../style/Button.style';
+
+/**-------------types-------------**/
+interface InputProps {
+  value: any;
+  onChange: any;
+}
+
+/**-------------Footer-------------**/
+export const S_FooterWrapper = styled(S_FlexBox)`
+  margin-top: 20px;
+
+  font-size: 0.8rem;
+
+  div {
+    margin-right: 8px;
+  }
+
+  button {
+    font-size: 1rem;
+  }
+`;
+export const S_SignUpButton = styled(S_Button)`
+  color: #0000ffc0;
+`;
+
+/**-------------LoginForm-------------**/
+export const S_LoginWrapper = styled.div`
+  width: 90%;
+  height: auto;
+`;
+export const S_Input = styled.input<InputProps>`
+  width: 100%;
+  height: auto;
+
+  margin-bottom: 12px;
+  padding: 13px 12px;
+
+  border: 1px solid #dedede;
+  border-radius: 4px;
+`;
+export const S_LogInButton = styled(S_Button)`
+  width: 100%;
+  padding: 13px 12px;
+
+  border: 1px solid #dedede;
+  border-radius: 4px;
+
+  background: #fff;
+`;
+
+/**-------------LoginForm-------------**/
+export const LogoWrapper = styled.div`
+  margin-bottom: 40px;
+`;

--- a/src/components/Main/AdditionalInformationModal.tsx
+++ b/src/components/Main/AdditionalInformationModal.tsx
@@ -1,16 +1,22 @@
-import styled from 'styled-components';
-import S_CenterBox from '../../style/CenterBox.style';
-import { S_FlexBox } from '../../style/FlexBox.style';
-import { S_Button } from '../../style/Button.style';
-
 import { useInput } from '../../hooks/useInput';
+import { S_FlexBox } from '../../style/FlexBox.style';
+import S_CenterBox from '../../style/CenterBox.style';
+
+import {
+  S_AdditionalInformationModalWrapper,
+  S_Label,
+  S_InputWrapper,
+  S_BlueBtn,
+  S_RedBtn,
+  S_Input,
+  S_Gender,
+  S_Unit,
+  S_RadioForm,
+  S_Title,
+} from './style';
 
 interface Props {
   modalHandler: () => void;
-}
-interface InputProps {
-  value: any;
-  onChange: any;
 }
 
 const AdditionalInformationModal = (props: Props) => {
@@ -31,9 +37,9 @@ const AdditionalInformationModal = (props: Props) => {
       innerBackgroundColor="#fff"
       outerBackgroundColor="rgba(238,238,238,0.8)"
     >
-      <S_Wrapper>
+      <S_AdditionalInformationModalWrapper>
         {/* 멘트 수정 가능 */}
-        <S_Title>추가 정보 입력</S_Title>
+        <S_Title marginBottom="30px">추가 정보 입력</S_Title>
 
         {/* 성별 radio 버튼 */}
         <S_InputWrapper>
@@ -93,81 +99,9 @@ const AdditionalInformationModal = (props: Props) => {
           <S_RedBtn onClick={onClickCloseModal}>취소</S_RedBtn>
           <S_BlueBtn>전송하기</S_BlueBtn>
         </S_FlexBox>
-      </S_Wrapper>
+      </S_AdditionalInformationModalWrapper>
     </S_CenterBox>
   );
 };
 
 export default AdditionalInformationModal;
-
-const S_Wrapper = styled(S_FlexBox)`
-  flex-direction: column;
-
-  width: 80%;
-  height: 80%;
-`;
-const S_Label = styled.label`
-  width: 20%;
-  color: gray;
-  font-size: 0.8rem;
-`;
-const S_InputWrapper = styled(S_FlexBox)`
-  width: 100%;
-  height: auto;
-
-  justify-content: flex-start;
-  margin-bottom: 20px;
-`;
-const S_Input = styled.input<InputProps>`
-  width: 30%;
-  height: auto;
-
-  padding: 13px 12px;
-  margin-right: 2px;
-
-  border: 1px solid #dedede;
-  border-radius: 4px;
-`;
-const S_Gender = styled.div`
-  width: 20%;
-  color: gray;
-  font-size: 0.8rem;
-  margin-left: 2px;
-`;
-const S_Title = styled(S_FlexBox)`
-  width: 100%;
-  font-size: 1.2rem;
-  font-weight: 500;
-
-  margin-bottom: 30px;
-`;
-const S_RadioForm = styled.form`
-  width: 80%;
-
-  display: flex;
-
-  div {
-    margin-right: 10px;
-  }
-  label {
-    padding-left: 5px;
-  }
-`;
-const S_Unit = styled(S_FlexBox)`
-  align-items: flex-end; // 왜 안먹지..
-  height: auto;
-`;
-
-// 버튼 상속
-const S_Btn = styled(S_Button)`
-  color: white;
-  font-weight: bold;
-  padding: 10px;
-`;
-const S_RedBtn = styled(S_Btn)`
-  background-color: red;
-  margin-right: 5px;
-`;
-const S_BlueBtn = styled(S_Btn)`
-  background-color: blue;
-`;

--- a/src/components/Main/ImgUploadModal.tsx
+++ b/src/components/Main/ImgUploadModal.tsx
@@ -1,10 +1,18 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import styled from 'styled-components';
 import S_CenterBox from '../../style/CenterBox.style';
-import { S_FlexBox } from '../../style/FlexBox.style';
-import { S_Button } from '../../style/Button.style';
+import {
+  S_BottomBtns,
+  S_BlankImg,
+  S_Img,
+  S_ImgWrapper,
+  S_RedBtn,
+  S_BlueBtn,
+  S_ImgUploadModalWrapper,
+  S_SelectWrapper,
+  S_Select,
+} from './style';
 
 interface Props {
   modalHandler: () => void;
@@ -71,7 +79,7 @@ const ImgUploadModal = (props: Props) => {
       innerBackgroundColor="#fff"
       outerBackgroundColor="rgba(238,238,238,0.8)"
     >
-      <S_Wrapper>
+      <S_ImgUploadModalWrapper>
         {/* 식사 선택  */}
         <S_SelectWrapper>
           <S_Select>
@@ -82,7 +90,7 @@ const ImgUploadModal = (props: Props) => {
           </S_Select>
         </S_SelectWrapper>
 
-        {/* 이미지 업로드, 미리보기  */}
+        {/* 이미지 업로드박스 or 이미지 미리보기  */}
         <S_ImgWrapper>
           {ImgFileBlob ? (
             <S_Img ref={imgRef} />
@@ -105,67 +113,9 @@ const ImgUploadModal = (props: Props) => {
           <S_RedBtn onClick={onClickCloseModal}>취소</S_RedBtn>
           <S_BlueBtn onClick={onClickUpload}>전송하기</S_BlueBtn>
         </S_BottomBtns>
-      </S_Wrapper>
+      </S_ImgUploadModalWrapper>
     </S_CenterBox>
   );
 };
 
 export default ImgUploadModal;
-
-const S_Wrapper = styled(S_FlexBox)`
-  width: 90%;
-  height: 90%;
-
-  flex-direction: column;
-  align-items: flex-start;
-`;
-const S_SelectWrapper = styled(S_FlexBox)`
-  justify-content: flex-start;
-  height: 20%;
-`;
-const S_Select = styled.select`
-  width: 100px;
-  height: 30px;
-`;
-const S_Btn = styled(S_Button)`
-  color: white;
-  font-weight: bold;
-  padding: 10px;
-`;
-const S_RedBtn = styled(S_Btn)`
-  background-color: red;
-  margin-right: 5px;
-`;
-const S_BlueBtn = styled(S_Btn)`
-  background-color: blue;
-`;
-const S_ImgWrapper = styled(S_FlexBox)`
-  width: 100%;
-  height: 60%;
-
-  & {
-    cursor: pointer;
-  }
-
-  > div {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background: #eee;
-    width: 100%;
-    height: 200px;
-  }
-`;
-const S_Img = styled.img`
-  width: 100%;
-  height: auto;
-`;
-const S_BlankImg = styled.div`
-  width: 200px;
-  height: 200px;
-`;
-const S_BottomBtns = styled(S_FlexBox)`
-  width: 100%;
-  height: 20%;
-  justify-content: flex-end;
-`;

--- a/src/components/Main/OneDayListContainer.tsx
+++ b/src/components/Main/OneDayListContainer.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import styled from 'styled-components';
 
 // Component
-import { S_FlexBox } from '../../style/FlexBox.style';
 import OneDayList from '../common/OneDayList';
+
+import { S_OneDayListContainerWrapper, S_DateWrapper, S_Total } from './style';
 
 interface Props {
   date: Date;
@@ -65,31 +65,14 @@ const OneDayListContainer = ({ date }: Props) => {
   };
 
   return (
-    <S_Wrapper>
+    <S_OneDayListContainerWrapper>
       <S_DateWrapper>
         <span>{DateParsing()}</span>
       </S_DateWrapper>
       <S_Total>총 {totalCalorie}kcal</S_Total>
       <OneDayList dataList={oneDayData} />
-    </S_Wrapper>
+    </S_OneDayListContainerWrapper>
   );
 };
 
 export default OneDayListContainer;
-
-const S_Wrapper = styled(S_FlexBox)`
-  flex-direction: column;
-  justify-content: space-evenly;
-  border: 1px solid;
-  width: 300px;
-  height: 450px;
-`;
-
-const S_DateWrapper = styled.div`
-  align-self: flex-start;
-  padding: 0 20px;
-`;
-
-const S_Total = styled.p`
-  font-weight: bold;
-`;

--- a/src/components/Main/TodayNutrition.tsx
+++ b/src/components/Main/TodayNutrition.tsx
@@ -1,11 +1,9 @@
 import { useState } from 'react';
 
-import styled from 'styled-components';
-import { S_FlexBox } from '../../style/FlexBox.style';
-import { S_Button } from '../../style/Button.style';
-
 import OneDayList from '../common/OneDayList';
 import ImgUploadModal from './ImgUploadModal';
+
+import { S_TodayNutritionWrapper, S_Title, S_UploadBtn } from './style';
 
 const TodayNutrition = () => {
   const [todayDayData, setTodayDayData] = useState([
@@ -62,7 +60,7 @@ const TodayNutrition = () => {
     <>
       {modal && <ImgUploadModal modalHandler={onClickImgUploadModalBtn} />}
 
-      <S_Wrapper>
+      <S_TodayNutritionWrapper>
         {/* Title */}
         <S_Title>Today</S_Title>
 
@@ -71,28 +69,9 @@ const TodayNutrition = () => {
 
         {/* 업로드 버튼 */}
         <S_UploadBtn onClick={onClickImgUploadModalBtn}>+</S_UploadBtn>
-      </S_Wrapper>
+      </S_TodayNutritionWrapper>
     </>
   );
 };
 
 export default TodayNutrition;
-
-const S_Wrapper = styled(S_FlexBox)`
-  width: 30%;
-  height: 450px;
-  max-width: 300px;
-
-  flex-direction: column;
-  justify-content: space-evenly;
-
-  border: 1px solid;
-`;
-const S_Title = styled(S_FlexBox)`
-  font-size: 1.3rem;
-  font-weight: 500;
-`;
-const S_UploadBtn = styled(S_Button)`
-  font-size: 1.8rem;
-  font-weight: 500;
-`;

--- a/src/components/Main/style/index.ts
+++ b/src/components/Main/style/index.ts
@@ -1,0 +1,165 @@
+import styled from 'styled-components';
+import { S_FlexBox } from '../../../style/FlexBox.style';
+import { S_Button } from '../../../style/Button.style';
+
+/**-------------types-------------**/
+interface InputProps {
+  value: any;
+  onChange: any;
+}
+/**-------------Common-------------**/
+export const S_Btn = styled(S_Button)`
+  color: white;
+  font-weight: bold;
+  padding: 10px;
+`;
+export const S_RedBtn = styled(S_Btn)`
+  background-color: red;
+  margin-right: 5px;
+`;
+export const S_BlueBtn = styled(S_Btn)`
+  background-color: blue;
+`;
+export const S_Title = styled(S_FlexBox)<{ marginBottom?: string }>`
+  width: 100%;
+  font-size: 1.2rem;
+  font-weight: 500;
+
+  margin-bottom: ${props => props.marginBottom};
+`;
+
+/**-------------AdditionalInformationModal-------------**/
+export const S_AdditionalInformationModalWrapper = styled(S_FlexBox)`
+  flex-direction: column;
+  justify-content: space-evenly;
+
+  width: 80%;
+  height: 80%;
+`;
+export const S_Label = styled.label`
+  width: 20%;
+  color: gray;
+  font-size: 0.8rem;
+`;
+export const S_InputWrapper = styled(S_FlexBox)`
+  width: 100%;
+  height: auto;
+
+  justify-content: flex-start;
+  margin-bottom: 20px;
+`;
+export const S_Input = styled.input<InputProps>`
+  width: 30%;
+  height: auto;
+
+  padding: 13px 12px;
+  margin-right: 2px;
+
+  border: 1px solid #dedede;
+  border-radius: 4px;
+`;
+export const S_Gender = styled.div`
+  width: 20%;
+  color: gray;
+  font-size: 0.8rem;
+  margin-left: 2px;
+`;
+
+export const S_RadioForm = styled.form`
+  width: 80%;
+
+  display: flex;
+
+  div {
+    margin-right: 10px;
+  }
+  label {
+    padding-left: 5px;
+  }
+`;
+export const S_Unit = styled(S_FlexBox)`
+  align-items: flex-end; // 왜 안먹지..
+  height: auto;
+`;
+
+/**-------------ImgUploadModal-------------**/
+export const S_ImgUploadModalWrapper = styled(S_FlexBox)`
+  width: 90%;
+  height: 90%;
+
+  flex-direction: column;
+  align-items: flex-start;
+`;
+export const S_SelectWrapper = styled(S_FlexBox)`
+  justify-content: flex-start;
+  height: 20%;
+`;
+export const S_Select = styled.select`
+  width: 100px;
+  height: 30px;
+`;
+export const S_ImgWrapper = styled(S_FlexBox)`
+  width: 100%;
+  height: 60%;
+
+  & {
+    cursor: pointer;
+  }
+
+  > div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: #eee;
+    width: 100%;
+    height: 200px;
+  }
+`;
+export const S_Img = styled.img`
+  width: 200px;
+  max-height: 100%;
+`;
+export const S_BlankImg = styled.div`
+  width: 200px;
+  height: 200px;
+`;
+export const S_BottomBtns = styled(S_FlexBox)`
+  width: 100%;
+  height: 20%;
+  justify-content: flex-end;
+`;
+
+/**-------------OneDayListContainer-------------**/
+export const S_OneDayListContainerWrapper = styled(S_FlexBox)`
+  flex-direction: column;
+  justify-content: space-evenly;
+  border: 1px solid;
+  width: 300px;
+  height: 450px;
+`;
+
+export const S_DateWrapper = styled.div`
+  align-self: flex-start;
+  padding: 0 20px;
+`;
+
+export const S_Total = styled.p`
+  font-weight: bold;
+`;
+
+/**-------------TodayNutrition-------------**/
+
+export const S_TodayNutritionWrapper = styled(S_FlexBox)`
+  width: 30%;
+  height: 450px;
+  max-width: 300px;
+
+  flex-direction: column;
+  justify-content: space-evenly;
+
+  border: 1px solid;
+`;
+export const S_UploadBtn = styled(S_Button)`
+  font-size: 1.8rem;
+  font-weight: 500;
+`;

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -1,16 +1,15 @@
-import { useRef, useEffect } from "react";
-import styled from "styled-components";
+import { useRef, useEffect } from 'react';
 
-import { useInput } from "../../hooks/useInput";
-import { useNavigate } from "react-router-dom";
+import { useInput } from '../../hooks/useInput';
+import { useNavigate } from 'react-router-dom';
 
-import { S_Button } from "../../style/Button.style";
-import { S_FlexBox } from "../../style/FlexBox.style";
-
-interface InputProps {
-  value: any;
-  onChange: any;
-}
+import {
+  S_BtnsWrapper,
+  S_BottomButton,
+  S_SignUpFormWrapper,
+  S_Input,
+  S_Label,
+} from './style';
 
 const SignUpForm = () => {
   const [email, onChangeEmail] = useInput('');
@@ -21,89 +20,61 @@ const SignUpForm = () => {
 
   const emailRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => { emailRef.current?.focus() }, []);
+  useEffect(() => {
+    emailRef.current?.focus();
+  }, []);
 
   const onClickLoginBtn = () => {
     navigate('/user/login');
-  }
+  };
   return (
-   <S_SignUpLayout>
-
+    <S_SignUpFormWrapper>
       {/* Input: email, password, rePassword */}
       <S_Label htmlFor="login-email">email</S_Label>
-      <S_Input 
-        value={ email }
-        onChange = { onChangeEmail }
-        placeholder='이메일'
-        name='login-email'
-        type='email' 
-        ref = { emailRef } />
+      <S_Input
+        value={email}
+        onChange={onChangeEmail}
+        placeholder="이메일"
+        name="login-email"
+        type="email"
+        ref={emailRef}
+      />
 
-      <S_Label style={{color: 'gray', fontSize: '0.8rem', marginLeft: '2px'}} htmlFor="ogin-email">password</S_Label>
-      <S_Input 
-        value={ password }
-        onChange = { onChangePassword }
-        placeholder='비밀번호'
-        name='signup-password'
-        type='password' />
+      <S_Label
+        style={{ color: 'gray', fontSize: '0.8rem', marginLeft: '2px' }}
+        htmlFor="ogin-email"
+      >
+        password
+      </S_Label>
+      <S_Input
+        value={password}
+        onChange={onChangePassword}
+        placeholder="비밀번호"
+        name="signup-password"
+        type="password"
+      />
 
-      <S_Label style={{color: 'gray', fontSize: '0.8rem', marginLeft: '2px'}} htmlFor="login-email">password check</S_Label>
-      <S_Input 
-        value={ rePassword }
-        onChange = { onChangeRePassword }
-        placeholder='비밀번호 확인'
-        name='signup-password-check'
-        type='password' />
+      <S_Label
+        style={{ color: 'gray', fontSize: '0.8rem', marginLeft: '2px' }}
+        htmlFor="login-email"
+      >
+        password check
+      </S_Label>
+      <S_Input
+        value={rePassword}
+        onChange={onChangeRePassword}
+        placeholder="비밀번호 확인"
+        name="signup-password-check"
+        type="password"
+      />
 
       {/* Login, Signup 버튼 */}
       <S_BtnsWrapper>
-        <S_BottomButton onClick={ onClickLoginBtn }>
-            LOGIN
-        </S_BottomButton>
-        <S_BottomButton>
-          SIGNUP
-        </S_BottomButton>
+        <S_BottomButton onClick={onClickLoginBtn}>LOGIN</S_BottomButton>
+        <S_BottomButton>SIGNUP</S_BottomButton>
       </S_BtnsWrapper>
-      
-   </S_SignUpLayout>
+    </S_SignUpFormWrapper>
   );
-}
+};
 
 export default SignUpForm;
-
-const S_BtnsWrapper = styled(S_FlexBox)`
-  margin-top: 20px;
-  
-  button:nth-child(1) {
-    margin-right: 10px;
-  } 
-`;
-const S_BottomButton = styled(S_Button)`
-  margin-bottom: 12px;
-  padding: 13px 12px;
-
-  border: 1px solid #dedede;
-  border-radius: 4px;
-
-  background-color: #fff;
-`;
-
-const S_SignUpLayout = styled.div`
-  height: auto;
-`;
-
-const S_Input = styled.input<InputProps>`
-  width: 100%;
-  height: auto;
-
-  margin-bottom: 12px;
-  padding: 13px 12px;
-
-  border: 1px solid #dedede;
-  border-radius: 4px;
-`;
-const S_Label = styled.label`
-  color: gray;
-  font-size: 0.8rem;
-  margin-left: 2px;
-`;

--- a/src/components/SignUp/Title.tsx
+++ b/src/components/SignUp/Title.tsx
@@ -1,20 +1,7 @@
-import styled from "styled-components";
-import { S_FlexBox } from "../../style/FlexBox.style";
+import { S_TitleWrapper } from './style';
 
 const Title = () => {
-  return (
-    <S_TitleLayout>
-      회원가입
-    </S_TitleLayout>
-  );
-}
+  return <S_TitleWrapper>회원가입</S_TitleWrapper>;
+};
 
 export default Title;
-
-const S_TitleLayout = styled(S_FlexBox)`
-  width: 100%;
-  margin: 30px 0;
-
-  font-weight: 500;
-  font-size: 1.2rem;
-`;

--- a/src/components/SignUp/style/index.ts
+++ b/src/components/SignUp/style/index.ts
@@ -1,0 +1,54 @@
+import styled from 'styled-components';
+import { S_FlexBox } from '../../../style/FlexBox.style';
+import { S_Button } from '../../../style/Button.style';
+
+/**-------------types-------------**/
+interface InputProps {
+  value: any;
+  onChange: any;
+}
+
+/**-------------SignUpForm-------------**/
+export const S_SignUpFormWrapper = styled.div`
+  height: auto;
+`;
+export const S_BtnsWrapper = styled(S_FlexBox)`
+  margin-top: 20px;
+
+  button:nth-child(1) {
+    margin-right: 10px;
+  }
+`;
+export const S_BottomButton = styled(S_Button)`
+  margin-bottom: 12px;
+  padding: 13px 12px;
+
+  border: 1px solid #dedede;
+  border-radius: 4px;
+
+  background-color: #fff;
+`;
+export const S_Input = styled.input<InputProps>`
+  width: 100%;
+  height: auto;
+
+  margin-bottom: 12px;
+  padding: 13px 12px;
+
+  border: 1px solid #dedede;
+  border-radius: 4px;
+`;
+export const S_Label = styled.label`
+  color: gray;
+  font-size: 0.8rem;
+  margin-left: 2px;
+`;
+
+/**-------------Title-------------**/
+export const S_TitleWrapper = styled(S_FlexBox)`
+  width: 100%;
+  margin: 30px 0;
+
+  font-weight: 500;
+  font-size: 1.2rem;
+`;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,19 +1,12 @@
-import styled from "styled-components";
-import { S_FlexBox } from "../../style/FlexBox.style";
+import { S_HeaderWrapper } from './style';
 
 const Header = () => {
   return (
-    <S_Wrapper>
-      <p>내밥몇칼로리?</p>  {/*로고*/}
-      <button>Login</button>  {/*로그인*/}
-    </S_Wrapper>
-  )
-}
+    <S_HeaderWrapper>
+      <p>내밥몇칼로리?</p> {/*로고*/}
+      <button>Login</button> {/*로그인*/}
+    </S_HeaderWrapper>
+  );
+};
 
 export default Header;
-
-const S_Wrapper = styled(S_FlexBox)`
-  justify-content: space-between;
-  height: 64px;
-  padding: 0 50px;
-`

--- a/src/components/common/OneDayList.tsx
+++ b/src/components/common/OneDayList.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { S_OneDayListtWrapper } from './style';
 
 // Component
 import OneMeal from './OneMeal';
@@ -17,16 +17,12 @@ interface Props {
 
 const OneDayList = ({ dataList }: Props) => {
   return (
-    <S_Content>
+    <S_OneDayListtWrapper>
       {dataList.map(data => {
         return <OneMeal data={data} />;
       })}
-    </S_Content>
+    </S_OneDayListtWrapper>
   );
 };
 
 export default OneDayList;
-
-const S_Content = styled.div`
-  width: 90%;
-`;

--- a/src/components/common/OneMeal.tsx
+++ b/src/components/common/OneMeal.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import styled from 'styled-components';
 
 // Component
-import { S_FlexBox } from '../../style/FlexBox.style';
 import OneMealDetailModal from './OneMealDetailModal';
+
+import { S_OneMealWrapper, S_Img } from './style';
 
 interface Props {
   data: {
@@ -35,27 +35,13 @@ const OneMeal = ({ data }: Props) => {
         onClickCloseModal={onClickCloseModal}
         data={data}
       />
-      <S_Wrapper onClick={onClickShowDetailModal}>
+      <S_OneMealWrapper onClick={onClickShowDetailModal}>
         <p>{data.time}</p>
-        <S_Img src={data.imgUrl} />
+        <S_Img src={data.imgUrl} width="40px" height="40px" />
         <p>{data.calorie}kcal</p>
-      </S_Wrapper>
+      </S_OneMealWrapper>
     </div>
   );
 };
 
 export default OneMeal;
-
-const S_Wrapper = styled(S_FlexBox)`
-  border: 1px solid;
-  height: 50px;
-  margin: 20px 0;
-  justify-content: space-evenly;
-  cursor: pointer;
-`;
-
-const S_Img = styled.img`
-  width: 40px;
-  height: 40px;
-  margin-right: 30px;
-`;

--- a/src/components/common/OneMealDetailModal.tsx
+++ b/src/components/common/OneMealDetailModal.tsx
@@ -1,9 +1,15 @@
-import styled from 'styled-components';
-
 // Component
 import S_CenterBox from '../../style/CenterBox.style';
-import { S_Button } from '../../style/Button.style';
-import { S_FlexBox } from '../../style/FlexBox.style';
+
+import {
+  S_OneMealDetailModalWrapper,
+  S_CloseBtn,
+  S_TimeWrapper,
+  S_ContentWrapper,
+  S_Img,
+  S_Content,
+  S_DetailMap,
+} from './style';
 
 interface Props {
   show: boolean;
@@ -29,13 +35,13 @@ const OneMealDetailModal = ({ show, onClickCloseModal, data }: Props) => {
       innerBackgroundColor="white"
       outerBackgroundColor="rgba(238,238,238,0.8)" // 변경 가능
     >
-      <S_Wrapper>
+      <S_OneMealDetailModalWrapper>
         <S_CloseBtn onClick={onClickCloseModal}>&times;</S_CloseBtn>
         <S_TimeWrapper>
           <p>{data.time}</p>
         </S_TimeWrapper>
         <S_ContentWrapper>
-          <S_Img src={data.imgUrl} />
+          <S_Img src={data.imgUrl} width="70%" />
           <S_Content>
             <p>총 {data.calorie}kcal</p>
             <S_DetailMap>
@@ -49,59 +55,8 @@ const OneMealDetailModal = ({ show, onClickCloseModal, data }: Props) => {
             </S_DetailMap>
           </S_Content>
         </S_ContentWrapper>
-      </S_Wrapper>
+      </S_OneMealDetailModalWrapper>
     </S_CenterBox>
   );
 };
 export default OneMealDetailModal;
-
-const S_Wrapper = styled(S_FlexBox)`
-  flex-direction: column;
-  justify-content: flex-start;
-  border: 1px solid;
-  width: 100%;
-  height: 100%;
-`;
-
-const S_CloseBtn = styled(S_Button)`
-  align-self: flex-end;
-`;
-
-const S_TimeWrapper = styled.div`
-  align-self: flex-start;
-  margin: 5% 10%;
-`;
-
-const S_ContentWrapper = styled(S_FlexBox)`
-  flex-direction: column;
-  justify-content: flex-start;
-  width: 90%;
-  height: 100%;
-`;
-
-const S_Img = styled.img`
-  width: 70%;
-`;
-
-const S_Content = styled(S_FlexBox)`
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  margin: 5% 0;
-  & > p {
-    margin: 2% 0;
-    font-weight: bold;
-  }
-`;
-
-const S_DetailMap = styled(S_FlexBox)`
-  flex-wrap: wrap;
-  width: 100%;
-  height: 100%;
-  // overflow-y: scroll;  - height 지정해야 함
-  overflow-y: scroll;
-  padding: 5px;
-  & > p {
-    margin: 2%;
-  }
-`;

--- a/src/components/common/style/index.ts
+++ b/src/components/common/style/index.ts
@@ -1,0 +1,79 @@
+import styled from 'styled-components';
+import { S_FlexBox } from '../../../style/FlexBox.style';
+import { S_Button } from '../../../style/Button.style';
+
+/**-------------types-------------**/
+interface square {
+  width?: string;
+  height?: string;
+}
+
+/**-------------Header-------------**/
+export const S_HeaderWrapper = styled(S_FlexBox)`
+  justify-content: space-between;
+  height: 64px;
+  padding: 0 50px;
+`;
+
+/**-------------OneDayList-------------**/
+export const S_OneDayListtWrapper = styled.div`
+  width: 90%;
+`;
+
+/**-------------OneMeal-------------**/
+export const S_OneMealWrapper = styled(S_FlexBox)`
+  border: 1px solid;
+  height: 50px;
+  margin: 20px 0;
+  justify-content: space-evenly;
+  cursor: pointer;
+`;
+export const S_Img = styled.img<square>`
+  width: ${props => props.width};
+  height: ${props => props.height};
+
+  margin-right: 30px;
+`;
+
+/**-------------OneMealDetailModal-------------**/
+export const S_OneMealDetailModalWrapper = styled(S_FlexBox)`
+  flex-direction: column;
+  justify-content: flex-start;
+  border: 1px solid;
+  width: 100%;
+  height: 100%;
+`;
+export const S_CloseBtn = styled(S_Button)`
+  align-self: flex-end;
+`;
+export const S_TimeWrapper = styled.div`
+  align-self: flex-start;
+  margin: 5% 10%;
+`;
+export const S_ContentWrapper = styled(S_FlexBox)`
+  flex-direction: column;
+  justify-content: flex-start;
+  width: 90%;
+  height: 100%;
+`;
+export const S_Content = styled(S_FlexBox)`
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  margin: 5% 0;
+  & > p {
+    margin: 2% 0;
+    font-weight: bold;
+  }
+`;
+export const S_DetailMap = styled(S_FlexBox)`
+  flex-wrap: wrap;
+  width: 100%;
+  height: 100%;
+  // overflow-y: scroll;  - height 지정해야 함
+  overflow-y: scroll;
+  padding: 5px;
+  & > p {
+    margin: 2%;
+  }
+`;

--- a/src/pages/Analysis/style.ts
+++ b/src/pages/Analysis/style.ts
@@ -14,10 +14,14 @@ export const S_ImgWrapper = styled(S_FlexBox)`
 export const S_DetailWrapper = styled(S_FlexBox)`
   flex-direction: column;
   justify-content: space-between;
+
   width: 100%;
   height: 80%;
+
   padding: 30px 0;
+
   border: 0.5px rgba(128, 128, 128, 0.39) solid;
+
   box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px,
     rgba(60, 64, 67, 0.15) 0px 1px 3px 1px;
   //box-shadow: rgba(0, 0, 0, 0.3) 0px 19px 38px,
@@ -33,12 +37,15 @@ export const S_InputCalorie = styled.input`
 `;
 
 export const S_SendBtn = styled(S_Button)`
-  background-color: #99d156;
-  color: rgba(0, 0, 0, 0.8);
-  font-weight: 500;
-  font-size: large;
   width: 90%;
   height: 10%;
+
+  background-color: #99d156;
+  color: rgba(0, 0, 0, 0.8);
+
+  font-weight: 500;
+  font-size: large;
+
   margin-top: 20px;
   border-radius: 10px;
   box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px,

--- a/src/pages/Main/style.ts
+++ b/src/pages/Main/style.ts
@@ -13,9 +13,11 @@ export const S_Box = styled(S_FlexBox)`
 `;
 
 export const S_BottomTitle = styled.p`
-  font-size: large;
-  margin-top: 3%;
-  text-align: center;
   width: 100%;
+
+  font-size: large;
+  text-align: center;
+
+  margin-top: 3%;
   border-top: 1px solid; // 임시
 `;

--- a/src/style/FlexBox.style.ts
+++ b/src/style/FlexBox.style.ts
@@ -13,7 +13,7 @@ interface FlexBoxProps {
 }
 
 export const S_FlexBox = styled.div<FlexBoxProps>`
-  width: ${props => props.width};
+  width: ${props => props.width || '100%'};
   height: ${props => props.height};
   margin: ${props => props.margin};
 


### PR DESCRIPTION
## chore/stylecomponent-folder-style -> main (Closes #26)✨

## 요약✏
- 컴포넌트의 styled-components -> 각 컴포넌트 폴더 아래 style/style.ts에 몰아넣기

## 구현 내용📝
- 각 컴포넌트에 딸려있던 styled-components를 src/[component]/style/index.ts로 통합
- FlexBox의 width 기본값 100% 추가
- 속성간 의미 비슷한것끼리 묶음(스크린샷 참조)

## Screenshots🎨
props 받게 변경
<img width="499" alt="스크린샷 2022-08-11 오후 9 49 37" src="https://user-images.githubusercontent.com/87258182/184140610-76839ab7-cacf-4218-8d9f-ef5524260bb0.png">
각 컴포넌트 사용
<img width="722" alt="스크린샷 2022-08-11 오후 9 49 17" src="https://user-images.githubusercontent.com/87258182/184140924-97a45a6c-f6a7-42af-bad4-162e1c93d165.png">
의미 비슷한것 묶기
<img width="716" alt="스크린샷 2022-08-11 오후 9 51 02" src="https://user-images.githubusercontent.com/87258182/184140792-068e256e-7eeb-4051-9ef4-d234ad95e47b.png">
공통되는 컴포넌트 상단에 common으로 뺌
<img width="526" alt="스크린샷 2022-08-11 오후 8 20 56" src="https://user-images.githubusercontent.com/87258182/184141384-75595c2c-cef4-4a55-b309-d38337385210.png">


## 관련 이슈🎯
- 각 컴포넌트에서 쓰인 styled-components명이 중첩되는 문제 발생
  - [컴포넌트명]Wrapper로 변경하여 해결 
 - 이 외에 공통으로 쓰인 변수명은 통합할 수 있으면 통합, 그렇지 않은 경우 일단은 props로 추가하여 각 컴포넌트에서 변경(스크린샷 참조)