### PR TITLE
[FEAT] sign up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.3",
         "@types/recharts": "^1.8.23",
+        "axios": "^0.27.2",
         "react": "^17.0.2",
         "react-calendar": "^3.7.0",
         "react-dom": "^17.0.2",
@@ -4579,6 +4580,28 @@
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -20019,6 +20042,27 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.3",
     "@types/recharts": "^1.8.23",
+    "axios": "^0.27.2",
     "react": "^17.0.2",
     "react-calendar": "^3.7.0",
     "react-dom": "^17.0.2",

--- a/src/actions/signUpAction.ts
+++ b/src/actions/signUpAction.ts
@@ -1,0 +1,26 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { domain } from '../utils/domain';
+import axios from 'axios';
+
+interface Result {
+  userId: number;
+  email: string;
+  name: string;
+}
+interface AsyncBasic {
+  sucess: boolean;
+  message: string;
+}
+
+export interface SignUp extends AsyncBasic {
+  result: Result;
+}
+export const signUp = createAsyncThunk(
+  'user/signup',
+  (data: any, thunkAPI): Promise<any> => {
+    return axios
+      .post(`${domain.jaeyoung_url}user/signup`, data)
+      .then(res => res.data as any)
+      .catch(res => alert(res)); // 서버 연결하고 수정 필요.
+  }
+);

--- a/src/actions/signUpAction.ts
+++ b/src/actions/signUpAction.ts
@@ -2,25 +2,34 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { domain } from '../utils/domain';
 import axios from 'axios';
 
-interface Result {
-  userId: number;
+// Types
+export interface ActionPayolad {
   email: string;
   name: string;
+  password: string;
+}
+interface Result {
+  result: {
+    userId: number;
+    email: string;
+    name: string;
+  };
 }
 interface AsyncBasic {
   sucess: boolean;
   message: string;
 }
-
 export interface SignUp extends AsyncBasic {
   result: Result;
 }
+
+// Thunk
 export const signUp = createAsyncThunk(
   'user/signup',
-  (data: any, thunkAPI): Promise<any> => {
+  (data: ActionPayolad, thunkAPI): Promise<SignUp> => {
     return axios
       .post(`${domain.jaeyoung_url}user/signup`, data)
-      .then(res => res.data as any)
+      .then(res => res.data)
       .catch(res => alert(res)); // 서버 연결하고 수정 필요.
   }
 );

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -1,9 +1,9 @@
-import { useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 
 import { useInput } from '../../hooks/useInput';
 import { useNavigate } from 'react-router-dom';
 
-import { SignUp, signUp, ActionPayolad } from '../../actions/signUpAction';
+import { signUp, ActionPayolad } from '../../actions/signUpAction';
 import { useAppSelector, useAppDispath } from '../../store/hooks';
 
 import { regExp } from '../../utils/regExp';
@@ -16,63 +16,60 @@ import {
   S_Label,
 } from './style';
 
+// Types
+interface Inputs {
+  value: string | React.Dispatch<React.SetStateAction<string>>;
+  alert: string;
+  ref: React.RefObject<HTMLInputElement>;
+}
+
+// Component
 const SignUpForm = () => {
+  // hooks
   const dispatch = useAppDispath();
   const navigate = useNavigate();
-
-  const status = useAppSelector(({ user }) => user.signUp.data);
-
-  useEffect(() => {
-    if (status) successSignUp();
-  }, [status]);
-
-  const successSignUp = () => {
-    alert(status!.message);
-    navigate('/user/login');
-  };
 
   const [email, onChangeEmail] = useInput('');
   const [name, onChangeName] = useInput('');
   const [password, onChangePassword] = useInput('');
   const [rePassword, onChangeRePassword] = useInput('');
 
+  // Selector
+  const status = useAppSelector(({ user }) => user.signUp.data);
+
+  // useEffects
+  useEffect(() => {
+    if (status) successSignUp();
+  }, [status]);
+  useEffect(() => {
+    emailRef.current?.focus();
+  }, []);
+
+  // Ref
   const emailRef = useRef<HTMLInputElement>(null);
   const nameRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
   const rePasswordRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    emailRef.current?.focus();
-  }, []);
+  const successSignUp = () => {
+    alert(status!.message);
+    navigate('/user/login');
+  };
 
   const ValidityCheck = () => {
+    const checkCategory = [
+      { value: email, alert: '이메일을 입력해주세요.', ref: emailRef },
+      { value: name, alert: '이름을 입력해주세요.', ref: nameRef },
+      { value: password, alert: '비밀번호를 입력해주세요.', ref: passwordRef },
+      {
+        value: rePassword,
+        alert: '비밀번호 확인을 입력해주세요.',
+        ref: rePasswordRef,
+      },
+    ];
+
     // null check
-    if (!email) {
-      alert('이메일을 입력해주세요.');
-      emailRef.current!.focus();
-
-      return;
-    } else if (!name) {
-      alert('이름을 입력해주세요.');
-      nameRef.current!.focus();
-
-      return;
-    } else if (!password) {
-      alert('비밀번호를 입력해주세요.');
-      passwordRef.current!.focus();
-
-      return;
-    } else if (!rePassword) {
-      alert('비밀번호 확인을 입력해주세요.');
-      rePasswordRef.current!.focus();
-
-      return;
-    } else if (!name) {
-      alert('이름을 입력해주세요.');
-      nameRef.current!.focus();
-
-      return;
-    }
+    if (!nullCheck(checkCategory)) return;
 
     // password equal check
     if (password !== rePassword) {
@@ -104,59 +101,57 @@ const SignUpForm = () => {
       dispatch(signUp({ email, name, password } as ActionPayolad));
     }
   };
+
+  const inputs = [
+    {
+      name: 'email',
+      inputValue: email,
+      onChange: onChangeEmail,
+      placeholder: '이메일',
+      type: 'email',
+      ref: emailRef,
+    },
+    {
+      name: 'name',
+      inputValue: name,
+      onChange: onChangeName,
+      placeholder: '이름',
+      type: 'text',
+      ref: nameRef,
+    },
+    {
+      name: 'password',
+      inputValue: password,
+      onChange: onChangePassword,
+      placeholder: '비밀번호',
+      type: 'password',
+      ref: passwordRef,
+    },
+    {
+      name: 'repassword',
+      inputValue: rePassword,
+      onChange: onChangeRePassword,
+      placeholder: '비밀번호 확인',
+      type: 'password',
+      ref: rePasswordRef,
+    },
+  ];
   return (
     <S_SignUpFormWrapper>
-      {/* Input: email, password, rePassword */}
-      <S_Label htmlFor="email">email</S_Label>
-      <S_Input
-        value={email}
-        onChange={onChangeEmail}
-        placeholder="이메일"
-        name="email"
-        type="email"
-        ref={emailRef}
-      />
-
-      <S_Label htmlFor="name">name</S_Label>
-      <S_Input
-        value={name}
-        onChange={onChangeName}
-        placeholder="이름"
-        name="name"
-        type="text"
-        ref={nameRef}
-      />
-
-      {/* TODO 인라인 스타일 */}
-      <S_Label
-        style={{ color: 'gray', fontSize: '0.8rem', marginLeft: '2px' }}
-        htmlFor="ogin-email"
-      >
-        password
-      </S_Label>
-      <S_Input
-        value={password}
-        onChange={onChangePassword}
-        placeholder="비밀번호"
-        name="signup-password"
-        type="password"
-        ref={passwordRef}
-      />
-
-      <S_Label
-        style={{ color: 'gray', fontSize: '0.8rem', marginLeft: '2px' }}
-        htmlFor="login-email"
-      >
-        password check
-      </S_Label>
-      <S_Input
-        value={rePassword}
-        onChange={onChangeRePassword}
-        placeholder="비밀번호 확인"
-        name="signup-password-check"
-        type="password"
-        ref={rePasswordRef}
-      />
+      {/* Inputs: email, name, password, rePassword */}
+      {inputs.map(input => (
+        <React.Fragment key={input.name}>
+          <S_Label htmlFor={input.name}>{input.name}</S_Label>
+          <S_Input
+            value={input.inputValue}
+            onChange={input.onChange}
+            placeholder={input.placeholder}
+            name={input.name}
+            type={input.type}
+            ref={input.ref}
+          />
+        </React.Fragment>
+      ))}
 
       {/* Login, Signup 버튼 */}
       <S_BtnsWrapper>
@@ -168,3 +163,15 @@ const SignUpForm = () => {
 };
 
 export default SignUpForm;
+
+const nullCheck = (checkCategory: Inputs[]) => {
+  for (let i = 0; i < checkCategory.length; i++) {
+    if (!checkCategory[i].value) {
+      alert(checkCategory[i].alert);
+      checkCategory[i].ref.current!.focus();
+
+      return false;
+    }
+  }
+  return true;
+};

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -3,7 +3,7 @@ import { useRef, useEffect } from 'react';
 import { useInput } from '../../hooks/useInput';
 import { useNavigate } from 'react-router-dom';
 
-import { SignUp, signUp } from '../../actions/signUpAction';
+import { SignUp, signUp, ActionPayolad } from '../../actions/signUpAction';
 import { useAppSelector, useAppDispath } from '../../store/hooks';
 
 import { regExp } from '../../utils/regExp';
@@ -27,7 +27,7 @@ const SignUpForm = () => {
   }, [status]);
 
   const successSignUp = () => {
-    alert(status.message);
+    alert(status!.message);
     navigate('/user/login');
   };
 
@@ -101,7 +101,7 @@ const SignUpForm = () => {
   };
   const onClickSignUpBtn = () => {
     if (ValidityCheck()) {
-      dispatch(signUp({ email, name, password }));
+      dispatch(signUp({ email, name, password } as ActionPayolad));
     }
   };
   return (

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -3,6 +3,9 @@ import { useRef, useEffect } from 'react';
 import { useInput } from '../../hooks/useInput';
 import { useNavigate } from 'react-router-dom';
 
+import { SignUp, signUp } from '../../actions/signUpAction';
+import { useAppSelector, useAppDispath } from '../../store/hooks';
+
 import {
   S_BtnsWrapper,
   S_BottomButton,
@@ -12,13 +15,29 @@ import {
 } from './style';
 
 const SignUpForm = () => {
+  const dispatch = useAppDispath();
+  const navigate = useNavigate();
+
+  const status = useAppSelector(({ user }) => user.signUp.data);
+
+  useEffect(() => {
+    if (status) successSignUp();
+  }, [status]);
+
+  const successSignUp = () => {
+    alert(status.message);
+    navigate('/user/login');
+  };
+
   const [email, onChangeEmail] = useInput('');
+  const [name, onChangeName] = useInput('');
   const [password, onChangePassword] = useInput('');
   const [rePassword, onChangeRePassword] = useInput('');
 
-  const navigate = useNavigate();
-
   const emailRef = useRef<HTMLInputElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const rePasswordRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     emailRef.current?.focus();
@@ -27,19 +46,33 @@ const SignUpForm = () => {
   const onClickLoginBtn = () => {
     navigate('/user/login');
   };
+  const onClickSignUpBtn = () => {
+    dispatch(signUp({ email, name, password }));
+  };
   return (
     <S_SignUpFormWrapper>
       {/* Input: email, password, rePassword */}
-      <S_Label htmlFor="login-email">email</S_Label>
+      <S_Label htmlFor="email">email</S_Label>
       <S_Input
         value={email}
         onChange={onChangeEmail}
         placeholder="이메일"
-        name="login-email"
+        name="email"
         type="email"
         ref={emailRef}
       />
 
+      <S_Label htmlFor="name">name</S_Label>
+      <S_Input
+        value={name}
+        onChange={onChangeName}
+        placeholder="이름"
+        name="name"
+        type="text"
+        ref={nameRef}
+      />
+
+      {/* TODO 인라인 스타일 */}
       <S_Label
         style={{ color: 'gray', fontSize: '0.8rem', marginLeft: '2px' }}
         htmlFor="ogin-email"
@@ -52,6 +85,7 @@ const SignUpForm = () => {
         placeholder="비밀번호"
         name="signup-password"
         type="password"
+        ref={passwordRef}
       />
 
       <S_Label
@@ -66,12 +100,13 @@ const SignUpForm = () => {
         placeholder="비밀번호 확인"
         name="signup-password-check"
         type="password"
+        ref={rePasswordRef}
       />
 
       {/* Login, Signup 버튼 */}
       <S_BtnsWrapper>
         <S_BottomButton onClick={onClickLoginBtn}>LOGIN</S_BottomButton>
-        <S_BottomButton>SIGNUP</S_BottomButton>
+        <S_BottomButton onClick={onClickSignUpBtn}>SIGNUP</S_BottomButton>
       </S_BtnsWrapper>
     </S_SignUpFormWrapper>
   );

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -6,6 +6,8 @@ import { useNavigate } from 'react-router-dom';
 import { SignUp, signUp } from '../../actions/signUpAction';
 import { useAppSelector, useAppDispath } from '../../store/hooks';
 
+import { regExp } from '../../utils/regExp';
+
 import {
   S_BtnsWrapper,
   S_BottomButton,
@@ -43,11 +45,64 @@ const SignUpForm = () => {
     emailRef.current?.focus();
   }, []);
 
+  const ValidityCheck = () => {
+    // null check
+    if (!email) {
+      alert('이메일을 입력해주세요.');
+      emailRef.current!.focus();
+
+      return;
+    } else if (!name) {
+      alert('이름을 입력해주세요.');
+      nameRef.current!.focus();
+
+      return;
+    } else if (!password) {
+      alert('비밀번호를 입력해주세요.');
+      passwordRef.current!.focus();
+
+      return;
+    } else if (!rePassword) {
+      alert('비밀번호 확인을 입력해주세요.');
+      rePasswordRef.current!.focus();
+
+      return;
+    } else if (!name) {
+      alert('이름을 입력해주세요.');
+      nameRef.current!.focus();
+
+      return;
+    }
+
+    // password equal check
+    if (password !== rePassword) {
+      alert('비밀번호와 비밀번호 확인이 같지 않습니다.');
+
+      passwordRef.current!.focus();
+      return;
+    }
+
+    // TODO 서버 조건에 맞는 멘트로 변경할 것
+    if (!regExp.isEmail(email as string)) {
+      alert('이메일 형식을 확인해주세요.');
+      return;
+    } else if (!regExp.isPassword(password as string)) {
+      alert(
+        '비밀번호는 대문자, 특수문자를 포함한 8자리 이상 16자리 이하여야 합니다.'
+      );
+      return;
+    }
+
+    return true;
+  };
+
   const onClickLoginBtn = () => {
     navigate('/user/login');
   };
   const onClickSignUpBtn = () => {
-    dispatch(signUp({ email, name, password }));
+    if (ValidityCheck()) {
+      dispatch(signUp({ email, name, password }));
+    }
   };
   return (
     <S_SignUpFormWrapper>

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -1,29 +1,20 @@
-import S_CenterBox from "../../style/CenterBox.style";
-import { S_FlexBox } from "../../style/FlexBox.style";
+import S_CenterBox from '../../style/CenterBox.style';
+import { S_FlexBox } from '../../style/FlexBox.style';
 
-import Title from "../../components/SignUp/Title";
-import SignUpForm from "../../components/SignUp/SignUpForm";
+import Title from '../../components/SignUp/Title';
+import SignUpForm from '../../components/SignUp/SignUpForm';
 
 const SignUp = () => {
-
   return (
-    <S_CenterBox 
-      width="350px"
-      height="400px"
-      innerBackgroundColor="#eee"
-      >
-      <S_FlexBox 
-        flexDirection="column"
-        width="90%">
-        
+    <S_CenterBox width="350px" height="500px" innerBackgroundColor="#eee">
+      <S_FlexBox flexDirection="column" width="90%">
         {/* Title */}
         <Title />
 
         {/* SignUpForm */}
         <SignUpForm />
-
       </S_FlexBox>
-    </S_CenterBox> 
+    </S_CenterBox>
   );
-}
+};
 export default SignUp;

--- a/src/slices/userSlice.ts
+++ b/src/slices/userSlice.ts
@@ -1,13 +1,13 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '../store/store';
-import { signUp } from '../actions/signUpAction';
+import { signUp, SignUp } from '../actions/signUpAction';
 
-interface SignUp {
-  signUp: { isLoading: boolean; data: string | null | any };
+interface User {
+  signUp: { isLoading: boolean; data: SignUp | null };
 }
 
 // login도 넣어야해서 객체로 감싼것
-const initialState: SignUp = {
+const initialState: User = {
   signUp: {
     isLoading: false,
     data: null,
@@ -19,14 +19,14 @@ const userSlice = createSlice({
   initialState,
   reducers: {},
   extraReducers: {
-    [signUp.pending.type]: (state: SignUp) => {
+    [signUp.pending.type]: (state: User) => {
       state.signUp.isLoading = true;
     },
-    [signUp.fulfilled.type]: (state: SignUp, action: PayloadAction<any>) => {
+    [signUp.fulfilled.type]: (state: User, action: PayloadAction<any>) => {
       state.signUp.isLoading = false;
       state.signUp.data = action.payload;
     },
-    [signUp.rejected.type]: (state: SignUp, action: PayloadAction<any>) => {
+    [signUp.rejected.type]: (state: User, action: PayloadAction<any>) => {
       state.signUp.isLoading = false;
     },
   },

--- a/src/slices/userSlice.ts
+++ b/src/slices/userSlice.ts
@@ -1,0 +1,35 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from '../store/store';
+import { signUp } from '../actions/signUpAction';
+
+interface SignUp {
+  signUp: { isLoading: boolean; data: string | null | any };
+}
+
+// login도 넣어야해서 객체로 감싼것
+const initialState: SignUp = {
+  signUp: {
+    isLoading: false,
+    data: null,
+  },
+};
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {},
+  extraReducers: {
+    [signUp.pending.type]: (state: SignUp) => {
+      state.signUp.isLoading = true;
+    },
+    [signUp.fulfilled.type]: (state: SignUp, action: PayloadAction<any>) => {
+      state.signUp.isLoading = false;
+      state.signUp.data = action.payload;
+    },
+    [signUp.rejected.type]: (state: SignUp, action: PayloadAction<any>) => {
+      state.signUp.isLoading = false;
+    },
+  },
+});
+
+export default userSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,9 +1,10 @@
-import { configureStore } from "@reduxjs/toolkit";
+import { configureStore } from '@reduxjs/toolkit';
+import userReducer from '../slices/userSlice';
 
-// slice 만들고 reducer에 등록하면 됩니다. 
+// slice 만들고 reducer에 등록하면 됩니다.
 const store = configureStore({
   reducer: {
-    
+    user: userReducer,
   },
   devTools: true,
 });

--- a/src/utils/domain.ts
+++ b/src/utils/domain.ts
@@ -1,0 +1,5 @@
+// 서버 생성시 삭제
+export const domain = {
+  jaeyoung_url: 'https://565331c9-e33b-456b-823f-d387162b44a2.mock.pstmn.io/',
+  hyowon_url: '',
+};

--- a/src/utils/regExp.ts
+++ b/src/utils/regExp.ts
@@ -1,0 +1,12 @@
+export const regExp = {
+  isEmail: (email: string) => {
+    const re =
+      /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
+    return re.test(email);
+  },
+  isPassword: (password: string) => {
+    const re =
+      /^(?=.*[a-zA-z])(?=.*[0-9])(?=.*[$`~!@$!%*#^?&\\(\\)\-_=+]).{8,16}$/;
+    return re.test(password);
+  },
+};


### PR DESCRIPTION
## feat/sign-up -> main(Closes #34)✨

## 요약✏
- thunk 사용하여 회원가입 비동기 요청 구현

## 구현 내용📝
- [x] slice에 초기 상태 정의 및 생성, action(thunk) 생성, store에 slice 등록
- [x] thunk로 비동기 요청

## Screenshots🎨
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/87258182/184471031-512b1ef9-3cfb-4b5d-8b57-ca1a16bbe035.gif)

## 관련 이슈🎯
- 유효성 검사 조건에 따라 alert 멘트 변경 가능. 
- 비동기 요청 실패 로직 추후 변경 가능.