### PR TITLE
[FEAT] user login 로직 구현

### DIFF
--- a/src/actions/logInAction.ts
+++ b/src/actions/logInAction.ts
@@ -1,0 +1,28 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { domain } from '../utils/domain';
+import axios from 'axios';
+
+import { AsyncBasic, Result } from './signUpAction';
+
+// Types
+export interface ActionPayolad {
+  email: string;
+  password: string;
+}
+
+// TODO token 저장 로직 구현
+export interface LogIn extends AsyncBasic {
+  result: Result;
+  accessToken: any; // 서버 연결 후 변경 예정
+}
+
+// Thunk
+export const logIn = createAsyncThunk(
+  'user/login',
+  (data: ActionPayolad, thunkAPI): Promise<LogIn> => {
+    return axios
+      .post(`${domain.jaeyoung_url}user/login`, data)
+      .then(res => res.data)
+      .catch(res => alert(res)); // 서버 연결하고 수정 필요.
+  }
+);

--- a/src/actions/signUpAction.ts
+++ b/src/actions/signUpAction.ts
@@ -8,14 +8,15 @@ export interface ActionPayolad {
   name: string;
   password: string;
 }
-interface Result {
+// TODO 공통 interface 위치 변경
+export interface Result {
   result: {
     userId: number;
     email: string;
     name: string;
   };
 }
-interface AsyncBasic {
+export interface AsyncBasic {
   sucess: boolean;
   message: string;
 }

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -4,15 +4,80 @@ import { useInput } from '../../hooks/useInput';
 
 import { S_LoginWrapper, S_Input, S_LogInButton } from './style';
 
+import { useAppSelector, useAppDispath } from '../../store/hooks';
+import { logIn, ActionPayolad } from '../../actions/logInAction';
+
+import { regExp } from '../../utils/regExp';
+import { useNavigate } from 'react-router-dom';
+
+import { nullCheck } from '../SignUp/SignUpForm';
+
+// Types
+interface Input {
+  value: string;
+  ref: React.RefObject<HTMLInputElement>;
+}
+interface form {
+  email: Input;
+  password: Input;
+}
+
+// Component
 const LoginForm = () => {
+  // hooks
+  const dispatch = useAppDispath();
+  const navigate = useNavigate();
+
+  const status = useAppSelector(({ user }) => user.logIn.data);
+
   const [email, onChangeEmail] = useInput('');
   const [password, onChangePassword] = useInput('');
 
+  // ref
   const emailRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
 
+  // email input focus
   useEffect(() => {
     emailRef.current?.focus();
   }, []);
+
+  // On successful login
+  useEffect(() => {
+    if (status) {
+      alert('로그인에 성공하였습니다.');
+
+      navigate('/main');
+    }
+  }, [status]);
+
+  const onClickLogInBtn = () => {
+    if (ValidityCheck()) {
+      const data = { email, password };
+
+      dispatch(logIn(data as ActionPayolad));
+    }
+  };
+
+  // 유효성 검사
+  const ValidityCheck = () => {
+    const checkCategory = [
+      { value: email, alert: '이메일을 입력해주세요.', ref: emailRef },
+      { value: password, alert: '비밀번호를 입력해주세요.', ref: passwordRef },
+    ];
+    const form = {
+      email: { value: email, ref: emailRef },
+      password: { value: password, ref: passwordRef },
+    };
+
+    // Null Check
+    if (!nullCheck(checkCategory)) return false;
+
+    // Format Check
+    if (!userFormatCheck(form as form)) return false;
+
+    return true;
+  };
 
   return (
     <S_LoginWrapper>
@@ -31,12 +96,31 @@ const LoginForm = () => {
         placeholder="비밀번호"
         name="login-password"
         type="password"
+        ref={passwordRef}
       />
 
       {/* Login button */}
-      <S_LogInButton>로그인</S_LogInButton>
+      <S_LogInButton onClick={onClickLogInBtn}>로그인</S_LogInButton>
     </S_LoginWrapper>
   );
 };
 
 export default LoginForm;
+
+// TODO SignUp에서도 적용 가능
+const userFormatCheck = (form: form) => {
+  if (!regExp.isEmail(form.email.value as string)) {
+    alert('이메일 형식을 확인해주세요.');
+    form.email.ref.current!.focus();
+
+    return false;
+  } else if (!regExp.isPassword(form.password.value as string)) {
+    alert(
+      '비밀번호는 대문자, 특수문자를 포함한 8자리 이상 16자리 이하여야 합니다.'
+    );
+    form.password.ref.current!.focus();
+
+    return false;
+  }
+  return true;
+};

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -164,7 +164,8 @@ const SignUpForm = () => {
 
 export default SignUpForm;
 
-const nullCheck = (checkCategory: Inputs[]) => {
+// TODO 공통 사용 분리 요망
+export const nullCheck = (checkCategory: Inputs[]) => {
   for (let i = 0; i < checkCategory.length; i++) {
     if (!checkCategory[i].value) {
       alert(checkCategory[i].alert);

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -35,7 +35,7 @@ const SignUpForm = () => {
   const [rePassword, onChangeRePassword] = useInput('');
 
   // Selector
-  const status = useAppSelector(({ user }) => user.signUp.data);
+  const status = useAppSelector(({ user }) => user.signUp.status);
 
   // useEffects
   useEffect(() => {
@@ -52,7 +52,7 @@ const SignUpForm = () => {
   const rePasswordRef = useRef<HTMLInputElement>(null);
 
   const successSignUp = () => {
-    alert(status!.message);
+    alert('회원가입에 성공하였습니다. 로그인 해주세요.');
     navigate('/user/login');
   };
 

--- a/src/slices/userSlice.ts
+++ b/src/slices/userSlice.ts
@@ -3,14 +3,14 @@ import type { RootState } from '../store/store';
 import { signUp, SignUp } from '../actions/signUpAction';
 
 interface User {
-  signUp: { isLoading: boolean; data: SignUp | null };
+  signUp: { isLoading: boolean; status: boolean };
 }
 
 // login도 넣어야해서 객체로 감싼것
 const initialState: User = {
   signUp: {
     isLoading: false,
-    data: null,
+    status: false,
   },
 };
 
@@ -22,11 +22,11 @@ const userSlice = createSlice({
     [signUp.pending.type]: (state: User) => {
       state.signUp.isLoading = true;
     },
-    [signUp.fulfilled.type]: (state: User, action: PayloadAction<any>) => {
+    [signUp.fulfilled.type]: (state: User) => {
       state.signUp.isLoading = false;
-      state.signUp.data = action.payload;
+      state.signUp.status = true;
     },
-    [signUp.rejected.type]: (state: User, action: PayloadAction<any>) => {
+    [signUp.rejected.type]: (state: User) => {
       state.signUp.isLoading = false;
     },
   },

--- a/src/slices/userSlice.ts
+++ b/src/slices/userSlice.ts
@@ -1,16 +1,21 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from '../store/store';
 import { signUp, SignUp } from '../actions/signUpAction';
+import { logIn, LogIn } from '../actions/logInAction';
 
 interface User {
   signUp: { isLoading: boolean; status: boolean };
+  logIn: { isLoading: boolean; data: LogIn | null };
 }
 
-// login도 넣어야해서 객체로 감싼것
 const initialState: User = {
   signUp: {
     isLoading: false,
     status: false,
+  },
+  logIn: {
+    isLoading: false,
+    data: null,
   },
 };
 
@@ -19,6 +24,7 @@ const userSlice = createSlice({
   initialState,
   reducers: {},
   extraReducers: {
+    // 회원가입
     [signUp.pending.type]: (state: User) => {
       state.signUp.isLoading = true;
     },
@@ -28,6 +34,17 @@ const userSlice = createSlice({
     },
     [signUp.rejected.type]: (state: User) => {
       state.signUp.isLoading = false;
+    },
+    // 로그인
+    [logIn.pending.type]: (state: User) => {
+      state.logIn.isLoading = true;
+    },
+    [logIn.fulfilled.type]: (state: User, action: PayloadAction<LogIn>) => {
+      state.logIn.isLoading = false;
+      state.logIn.data = action.payload;
+    },
+    [logIn.rejected.type]: (state: User) => {
+      state.logIn.isLoading = false;
     },
   },
 });


### PR DESCRIPTION
## feat/user-login -> main (Closes #33)✨

## 요약✏
- thunk 사용하여 로그인 비동기 요청 구현

## 구현 내용📝
- [x]  slice에 초기 상태 정의 및 생성, action(thunk) 생성
- [x]  thunk로 비동기 요청

## Screenshots🎨
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/87258182/184492888-bda05534-7096-468a-ad8b-8aa8c969a449.gif)

## 관련 이슈🎯
- 중복되는 함수, 타입 저장 위치 논의 필요
- 회원가입 성공시 redux 스토어에 저장하던 유저 정보를 boolean으로 변경(login시 정보 중복)
- 로그인 HOC는 쿠키값이 아닌 전역 스토어 값을 참조할 예정(서버에 전송을 위해 로그인시 쿠키는 저장함)
