### PR TITLE
[FEAT] login-auth 구현

### DIFF
--- a/src/actions/signUpAction.ts
+++ b/src/actions/signUpAction.ts
@@ -17,7 +17,7 @@ export interface Result {
   };
 }
 export interface AsyncBasic {
-  sucess: boolean;
+  success: boolean;
   message: string;
 }
 export interface SignUp extends AsyncBasic {

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -10,6 +10,9 @@ import { S_Footer } from '../../style/Footer.style';
 import { S_BottomTitle, S_Box } from './style';
 import { S_FlexBox } from '../../style/FlexBox.style';
 
+// HOC
+import Auth from '../../utils/auth';
+
 const Main = () => {
   const [date, setDate] = useState(new Date());
 
@@ -40,4 +43,4 @@ const Main = () => {
   );
 };
 
-export default Main;
+export default Auth(Main);

--- a/src/utils/auth.tsx
+++ b/src/utils/auth.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAppSelector } from '../store/hooks';
+
+const auth = (Component: () => JSX.Element) => {
+  const LoginCheck = () => {
+    const navigate = useNavigate();
+    const loginData = useAppSelector(({ user }) => user.logIn.data);
+
+    useEffect(() => {
+      if (!loginData) {
+        alert('로그인 후 이용해 주세요.');
+
+        navigate('/user/login');
+      }
+    }, []);
+
+    return <Component />;
+  };
+
+  return LoginCheck;
+};
+
+export default auth;


### PR DESCRIPTION
## feat/login-auth -> main (Closes #50)✨

## 요약✏
 login-auth 구현

## 구현 내용📝
- [x] HOC, useSelector 사용하여 login auth 구현

## Screenshots🎨

### 로그인시 main 페이지 정상 이동
<img width='60%' src='https://user-images.githubusercontent.com/87258182/184621438-427f9415-2f5d-405b-a6d8-0fedc96ac95a.gif'>

### 미로그인시 login 페이지 이동
<img  width='60%' src='https://user-images.githubusercontent.com/87258182/184621767-45493fe6-f072-4980-8368-9204b000ace9.gif' >


## 관련 이슈🎯
- 새로고침시 전역 스토어 값 사라짐 -> 로그인페이지 이동됨
- 서버 준비되면 로그인 유무를 session storage 저장으로 변경예정
