### PR TITLE
[FEAT] login auth

### DIFF
--- a/src/actions/logInAction.ts
+++ b/src/actions/logInAction.ts
@@ -23,6 +23,6 @@ export const logIn = createAsyncThunk(
     return axios
       .post(`${domain.jaeyoung_url}user/login`, data)
       .then(res => res.data)
-      .catch(res => alert(res)); // 서버 연결하고 수정 필요.
+      .catch(err => err); // TODO 서버 연결하고 수정 필요.
   }
 );

--- a/src/actions/signUpAction.ts
+++ b/src/actions/signUpAction.ts
@@ -31,6 +31,6 @@ export const signUp = createAsyncThunk(
     return axios
       .post(`${domain.jaeyoung_url}user/signup`, data)
       .then(res => res.data)
-      .catch(res => alert(res)); // 서버 연결하고 수정 필요.
+      .catch(err => err); // TODO 서버 연결하고 수정 필요.
   }
 );

--- a/src/actions/signUpAction.ts
+++ b/src/actions/signUpAction.ts
@@ -17,7 +17,7 @@ export interface Result {
   };
 }
 export interface AsyncBasic {
-  sucess: boolean;
+  success: boolean;
   message: string;
 }
 export interface SignUp extends AsyncBasic {

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -5,7 +5,7 @@ import { useInput } from '../../hooks/useInput';
 import { S_LoginWrapper, S_Input, S_LogInButton, S_Boundary } from './style';
 import { S_Button } from '../../style/Button.style';
 
-import { useAppSelector, useAppDispath } from '../../store/hooks';
+import { useAppDispath } from '../../store/hooks';
 import { logIn, ActionPayolad } from '../../actions/logInAction';
 
 import { regExp } from '../../utils/regExp';
@@ -31,8 +31,6 @@ const LoginForm = () => {
   const dispatch = useAppDispath();
   const navigate = useNavigate();
 
-  const status = useAppSelector(({ user }) => user.logIn.data);
-
   const [email, onChangeEmail] = useInput('');
   const [password, onChangePassword] = useInput('');
 
@@ -45,20 +43,24 @@ const LoginForm = () => {
     emailRef.current?.focus();
   }, []);
 
-  // On successful login
-  useEffect(() => {
-    if (status) {
-      alert('로그인에 성공하였습니다.');
+  const succeedInLogIn = (userData: {}) => {
+    // TODO 세션 저장 정보 추후 변경 가능
+    window.sessionStorage.setItem('loggedInfo', JSON.stringify(userData));
 
-      navigate('/main');
-    }
-  }, [status]);
+    alert('로그인에 성공했습니다.');
+
+    navigate('/main');
+  };
 
   const onClickLogInBtn = () => {
     if (ValidityCheck()) {
       const data = { email, password };
 
-      dispatch(logIn(data as ActionPayolad));
+      // 로그인 성공시 유저 정보 세션에 저장해야함
+      dispatch(logIn(data as ActionPayolad))
+        .unwrap()
+        .then(res => res.success && succeedInLogIn(res))
+        .catch(err => alert('로그인에 실패했습니다. 다시 시도해 주세요.'));
     }
   };
 

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -4,7 +4,7 @@ import { useInput } from '../../hooks/useInput';
 import { useNavigate } from 'react-router-dom';
 
 import { signUp, ActionPayolad } from '../../actions/signUpAction';
-import { useAppSelector, useAppDispath } from '../../store/hooks';
+import { useAppDispath } from '../../store/hooks';
 
 import { regExp } from '../../utils/regExp';
 
@@ -16,7 +16,6 @@ import {
   S_Input,
   S_Label,
 } from './style';
-import { S_Button } from '../../style/Button.style';
 
 // Types
 interface Inputs {
@@ -36,13 +35,7 @@ const SignUpForm = () => {
   const [password, onChangePassword] = useInput('');
   const [rePassword, onChangeRePassword] = useInput('');
 
-  // Selector
-  const status = useAppSelector(({ user }) => user.signUp.status);
-
   // useEffects
-  useEffect(() => {
-    if (status) successSignUp();
-  }, [status]);
   useEffect(() => {
     emailRef.current?.focus();
   }, []);
@@ -52,11 +45,6 @@ const SignUpForm = () => {
   const nameRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
   const rePasswordRef = useRef<HTMLInputElement>(null);
-
-  const successSignUp = () => {
-    alert('회원가입에 성공하였습니다. 로그인 해주세요.');
-    navigate('/user/login');
-  };
 
   const ValidityCheck = () => {
     const checkCategory = [
@@ -95,12 +83,21 @@ const SignUpForm = () => {
     return true;
   };
 
+  const succeedInSignUp = () => {
+    alert('회원가입에 성공하였습니다. 로그인 해주세요.');
+    navigate('/user/login');
+  };
+
   const onClickLoginBtn = () => {
     navigate('/user/login');
   };
+
   const onClickSignUpBtn = () => {
     if (ValidityCheck()) {
-      dispatch(signUp({ email, name, password } as ActionPayolad));
+      dispatch(signUp({ email, name, password } as ActionPayolad))
+        .unwrap()
+        .then(res => res.success && succeedInSignUp())
+        .catch(err => alert('회원가입에 실패하였습니다. 다시 시도해 주세요.'));
     }
   };
 

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -10,6 +10,9 @@ import { S_Footer } from '../../style/Footer.style';
 import { S_BottomTitle, S_Box } from './style';
 import { S_FlexBox } from '../../style/FlexBox.style';
 
+// HOC
+import Auth from '../../utils/auth';
+
 const Main = () => {
   const [date, setDate] = useState(new Date());
 
@@ -40,4 +43,4 @@ const Main = () => {
   );
 };
 
-export default Main;
+export default Auth(Main);

--- a/src/utils/auth.tsx
+++ b/src/utils/auth.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAppSelector } from '../store/hooks';
+
+const auth = (Component: () => JSX.Element) => {
+  const LoginCheck = () => {
+    const navigate = useNavigate();
+    const loginData = useAppSelector(({ user }) => user.logIn.data);
+
+    useEffect(() => {
+      if (!loginData) {
+        alert('로그인 후 이용해 주세요.');
+
+        navigate('/user/login');
+      }
+    }, []);
+
+    return <Component />;
+  };
+
+  return LoginCheck;
+};
+
+export default auth;

--- a/src/utils/auth.tsx
+++ b/src/utils/auth.tsx
@@ -1,14 +1,16 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAppSelector } from '../store/hooks';
 
 const auth = (Component: () => JSX.Element) => {
   const LoginCheck = () => {
     const navigate = useNavigate();
-    const loginData = useAppSelector(({ user }) => user.logIn.data);
+
+    const sessionLoggedInfo = JSON.parse(
+      sessionStorage.getItem('loggedInfo') as string
+    );
 
     useEffect(() => {
-      if (!loginData) {
+      if (!sessionLoggedInfo) {
         alert('로그인 후 이용해 주세요.');
 
         navigate('/user/login');


### PR DESCRIPTION
## feat/login-auth -> main (Closes #50)✨

## 요약✏
 login-auth 구현

## 구현 내용📝
- [x] HOC, useSelector 사용하여 login auth 구현. 
- [x] login. signup thunk 정상 처리시 useEffect로 처리하던것을 unwrap 사용하여 코드 응집도 올림
 
## Screenshots🎨

### 로그인시 main 페이지 정상 이동
<img width='60%' src='https://user-images.githubusercontent.com/87258182/184621438-427f9415-2f5d-405b-a6d8-0fedc96ac95a.gif'>

### 미로그인시 login 페이지 이동
<img  width='60%' src='https://user-images.githubusercontent.com/87258182/184621767-45493fe6-f072-4980-8368-9204b000ace9.gif' >

### 새로고침시 로그인 유지
<img width='60%' src='https://user-images.githubusercontent.com/87258182/184638111-d8016afe-9363-432a-9a47-ef040dc0d293.gif'>

### unwrap 사용
<img width="754" alt="스크린샷 2022-08-15 오후 10 00 38" src="https://user-images.githubusercontent.com/87258182/184639685-f62b8e4e-b38d-461a-b405-0115b6393af2.png">


## 관련 이슈🎯
- redux store 사용하여 auth 구현시 새로고침시 로그인 풀렸는데 sessionStorage 사용하여 해결
