### PR TITLE
[STYLE] 이미지 분석 페이지 확인 안내 말풍선 UI

### DIFF
--- a/src/pages/Analysis/index.tsx
+++ b/src/pages/Analysis/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import {
   S_CalorieDetailWrapper,
+  S_CheckInform,
   S_DetailWrapper,
   S_ImgWrapper,
   S_InputCalorie,
@@ -12,6 +13,8 @@ import { S_Box } from '../Main/style';
 import { S_FlexBox } from '../../style/FlexBox.style';
 
 const Analysis = () => {
+  const [time, setTime] = useState('아침');
+
   const [imgUrl, setImgUrl] = useState(
     'https://cdn.imweb.me/upload/S20200615b0849c262a5bf/d91910c88d19f.jpg'
   );
@@ -34,7 +37,7 @@ const Analysis = () => {
               <p>{data.name}</p>
               <div>
                 <S_InputCalorie value={data.calorie} />
-                <span>kcal</span>
+                <span> kcal</span>
               </div>
             </S_FlexBox>
           );
@@ -46,15 +49,18 @@ const Analysis = () => {
   return (
     <div>
       <Header />
+      <S_CheckInform>
+        <span>칼로리 정보를 확인하고 수정해주세요!</span>
+      </S_CheckInform>
       <S_FlexBox margin="64px 0 0 0">
         <S_Box>
           <S_ImgWrapper>
-            <S_Time>아침</S_Time>
+            {/*<S_Time>아침</S_Time>*/}
             <img src={imgUrl} />
           </S_ImgWrapper>
           <S_FlexBox flexDirection="column" width="300px" height="500px">
             <S_DetailWrapper>
-              <p>칼로리 정보</p>
+              <p>{`오늘의 ${time}`}</p>
               <CalorieDetail />
               <S_FlexBox
                 justifyContent="space-between"
@@ -62,7 +68,7 @@ const Analysis = () => {
                 height="50px"
               >
                 <p>총 칼로리</p>
-                <p>{totalCalorie}kcal</p>
+                <p>{totalCalorie} kcal</p>
               </S_FlexBox>
             </S_DetailWrapper>
             <S_SendBtn>저장하기</S_SendBtn>

--- a/src/pages/Analysis/style.ts
+++ b/src/pages/Analysis/style.ts
@@ -2,6 +2,29 @@ import styled from 'styled-components';
 import { S_FlexBox } from '../../style/FlexBox.style';
 import { S_Button } from '../../style/Button.style';
 
+export const S_CheckInform = styled.div`
+  position: absolute;
+  top: 100px;
+  right: 5%;
+
+  padding: 10px;
+  border-radius: 10px;
+  text-align: center;
+  background: #fee365;
+  font-style: italic;
+
+  :after {
+    border-top: 10px solid #fee365;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-bottom: 0px solid transparent;
+    content: '';
+    position: absolute;
+    bottom: -10px;
+    right: 70%;
+  }
+`;
+
 export const S_ImgWrapper = styled(S_FlexBox)`
   flex-direction: column;
   width: 50%;
@@ -37,6 +60,7 @@ export const S_CalorieDetailWrapper = styled.div`
 
 export const S_InputCalorie = styled.input`
   width: 40px;
+  text-align: right;
 `;
 
 export const S_SendBtn = styled(S_Button)`


### PR DESCRIPTION
## ui-design -> main (Closes #37 )✨

## 요약✏
- 이미지 분석 페이지 확인 안내 말풍선 UI 및 디자인 구현

## 구현 내용📝
- 확인 안내 말풍선 배치
- 칼로리 정보 영역의 상단 멘트 변경(칼로리 정보 -> 오늘의 아침/점심/저녁/간식)
- 칼로리 수정 입력창 텍스트 오른정렬

## Screenshots🎨
<img width="300" alt="image" src="https://user-images.githubusercontent.com/78535339/184663393-f8a92ba4-9883-475c-be6a-18f2a0816700.png">


## 관련 이슈🎯
- position: absolute로 배치
