### PR TITLE
[FEAT] header route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^17.0.2",
         "react-calendar": "^3.7.0",
         "react-dom": "^17.0.2",
+        "react-icons": "^4.4.0",
         "react-redux": "^8.0.2",
         "react-router-dom": "^6.3.0",
         "react-scripts": "^5.0.1",
@@ -13810,6 +13811,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -26570,6 +26579,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "react": "^17.0.2",
     "react-calendar": "^3.7.0",
     "react-dom": "^17.0.2",
+    "react-icons": "^4.4.0",
     "react-redux": "^8.0.2",
     "react-router-dom": "^6.3.0",
     "react-scripts": "^5.0.1",

--- a/src/components/Home/Main.tsx
+++ b/src/components/Home/Main.tsx
@@ -18,6 +18,10 @@ interface Props {
 const Main = (props: Props) => {
   const navigate = useNavigate();
 
+  const sessionLoggedInfo = JSON.parse(
+    sessionStorage.getItem('loggedInfo') as string
+  );
+
   const onClickLogin = () => navigate('/user/login');
   const onClickSignup = () => navigate('/user/signup');
 
@@ -35,10 +39,16 @@ const Main = (props: Props) => {
         <S_P>{props.ment}</S_P>
 
         {/* buttons */}
-        <S_BottomBtns>
-          <S_Btn onClick={onClickLogin}>로그인</S_Btn>
-          <S_Btn onClick={onClickSignup}>회원가입</S_Btn>
-        </S_BottomBtns>
+        {!sessionLoggedInfo ? (
+          <S_BottomBtns>
+            <S_Btn onClick={onClickLogin}>로그인</S_Btn>
+            <S_Btn onClick={onClickSignup}>회원가입</S_Btn>
+          </S_BottomBtns>
+        ) : (
+          <S_BottomBtns>
+            <S_Btn onClick={() => navigate('/main')}>메인</S_Btn>
+          </S_BottomBtns>
+        )}
       </S_MainWrapper>
     </>
   );

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,10 +1,13 @@
 import { S_HeaderWrapper, S_MainLogo } from './style';
 import Logo from './../../assets/main_logo.png';
+import { useNavigate } from 'react-router-dom';
 
 const Header = () => {
+  const navigate = useNavigate();
+
   return (
     <S_HeaderWrapper>
-      <S_MainLogo src={Logo} /> {/*로고*/}
+      <S_MainLogo src={Logo} onClick={() => navigate('/')} /> {/*로고*/}
       <button>Login</button> {/*로그인*/}
     </S_HeaderWrapper>
   );

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,14 +1,23 @@
 import { S_HeaderWrapper, S_MainLogo } from './style';
 import Logo from './../../assets/main_logo.png';
 import { useNavigate } from 'react-router-dom';
+import { MdLogout } from 'react-icons/md';
 
 const Header = () => {
   const navigate = useNavigate();
 
+  const sessionLoggedInfo = JSON.parse(
+    sessionStorage.getItem('loggedInfo') as string
+  );
+
   return (
     <S_HeaderWrapper>
       <S_MainLogo src={Logo} onClick={() => navigate('/')} /> {/*로고*/}
-      <button>Login</button> {/*로그인*/}
+      {!sessionLoggedInfo ? (
+        <></>
+      ) : (
+        <MdLogout size="1.5rem" style={{ cursor: 'pointer' }} />
+      )}
     </S_HeaderWrapper>
   );
 };

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -10,13 +10,27 @@ const Header = () => {
     sessionStorage.getItem('loggedInfo') as string
   );
 
+  const onLogout = () => {
+    const logout = window.confirm('로그아웃 하시겠습니까?');
+
+    if (logout) {
+      sessionStorage.removeItem('loggedInfo');
+      alert('로그아웃 되었습니다.');
+      window.location.reload();
+    }
+  };
+
   return (
     <S_HeaderWrapper>
       <S_MainLogo src={Logo} onClick={() => navigate('/')} /> {/*로고*/}
       {!sessionLoggedInfo ? (
         <></>
       ) : (
-        <MdLogout size="1.5rem" style={{ cursor: 'pointer' }} />
+        <MdLogout
+          size="1.5rem"
+          style={{ cursor: 'pointer' }}
+          onClick={onLogout}
+        />
       )}
     </S_HeaderWrapper>
   );

--- a/src/components/common/style/index.ts
+++ b/src/components/common/style/index.ts
@@ -27,6 +27,7 @@ export const S_HeaderWrapper = styled(S_FlexBox)`
 
 export const S_MainLogo = styled.img`
   width: 90px;
+  cursor: pointer;
 `;
 
 /**-------------OneDayList-------------**/


### PR DESCRIPTION
## feat/header-route -> main (Closes #53 )✨

## 요약✏
- 로그인 유무에 따른 페이지 이동 처리

## 구현 내용📝
- 헤더 메인 로고 클릭 시 home 페이지로 이동
- 로그인X - home 페이지 중앙에 로그인/회원가입 버튼 배치
- 로그인O - home 페이지 중앙에 main 페이지로 이동하는 버튼 배치, 헤더 우측에 로그아웃 버튼 배치
- 로그아웃 기능 구현

## Screenshots🎨
<img width="500" alt="스크린샷 2022-08-16 오후 1 09 37" src="https://user-images.githubusercontent.com/78535339/184796213-dcafeb65-82d4-4ece-86aa-1e974b024faf.png">

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/78535339/184796260-8373b0ac-e978-41d6-a7e0-b3466f55c2c7.gif)


## 관련 이슈🎯
