### PR TITLE
[STYLE] 이미지 업로드 모달 크기 조정

### DIFF
--- a/src/components/Main/ImgUploadModal.tsx
+++ b/src/components/Main/ImgUploadModal.tsx
@@ -74,8 +74,8 @@ const ImgUploadModal = (props: Props) => {
 
   return (
     <S_CenterBox
-      width="400px"
-      height="400px"
+      width="500px"
+      height="500px"
       innerBackgroundColor="#fff"
       outerBackgroundColor="rgba(238,238,238,0.8)"
       boxShadow="rgba(0, 0, 0, 0.25) 0px 54px 55px, rgba(0, 0, 0, 0.12) 0px -12px 30px, rgba(0, 0, 0, 0.12) 0px 4px 6px, rgba(0, 0, 0, 0.17) 0px 12px 13px, rgba(0, 0, 0, 0.09) 0px -3px 5px"

--- a/src/components/Main/style/index.ts
+++ b/src/components/Main/style/index.ts
@@ -112,23 +112,16 @@ export const S_ImgWrapper = styled(S_FlexBox)`
   & {
     cursor: pointer;
   }
-
-  > div {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background: #eee;
-    width: 100%;
-    height: 200px;
-  }
 `;
 export const S_Img = styled.img`
-  width: 200px;
+  max-width: 100%;
   max-height: 100%;
 `;
-export const S_BlankImg = styled.div`
-  width: 200px;
-  height: 200px;
+export const S_BlankImg = styled(S_FlexBox)`
+  width: 100%;
+  height: 250px;
+
+  background: #eee;
 `;
 export const S_BottomBtns = styled(S_FlexBox)`
   width: 100%;


### PR DESCRIPTION
## ui-design -> main ✨

## 요약✏
이미지 업로드 모달 크기 조정

## 구현 내용📝
- 400x400 -> 500x500으로 변경

## Screenshots🎨

<img width="80%" alt="스크린샷 2022-08-16 오후 1 16 51" src="https://user-images.githubusercontent.com/87258182/184796815-96dcb675-4234-4a7b-9280-63dbdaa5162c.png">
<img width="80%" alt="스크린샷 2022-08-16 오후 1 16 57" src="https://user-images.githubusercontent.com/87258182/184796832-1a7c5f30-2ebf-48fd-b557-25ded98d0bd5.png">


## 관련 이슈🎯
