### PR TITLE
[FIX] 선택 날짜 데이터 각 컴포넌트에서 받아오도록 수정

### DIFF
--- a/src/components/Main/CalendarContainer.tsx
+++ b/src/components/Main/CalendarContainer.tsx
@@ -3,15 +3,13 @@ import './style/calendar.css';
 import { S_FlexBox } from '../../style/FlexBox.style';
 import { S_CalendarTitle } from './style';
 
-import { useAppDispath } from '../../_store/hooks';
+import { useAppDispath, useAppSelector } from '../../_store/hooks';
 import { changeDate } from '../../_slices/dateSlice';
 
-interface Props {
-  date: Date;
-}
-
-const CalendarContainer = ({ date }: Props) => {
+const CalendarContainer = () => {
   const dispatch = useAppDispath();
+
+  const date = useAppSelector(state => state.date.value);
 
   const onChangeDate = (e: any) => {
     dispatch(changeDate(e));

--- a/src/components/Main/OneDayListContainer.tsx
+++ b/src/components/Main/OneDayListContainer.tsx
@@ -9,12 +9,11 @@ import {
   S_Total,
   S_CalorieTxt,
 } from './style';
+import { useAppSelector } from '../../_store/hooks';
 
-interface Props {
-  date: Date;
-}
+const OneDayListContainer = () => {
+  const date = useAppSelector(state => state.date.value);
 
-const OneDayListContainer = ({ date }: Props) => {
   const [totalCalorie, setTotalCalorie] = useState(2000);
 
   const [oneDayData, setOneDayData] = useState([

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -1,5 +1,3 @@
-import React, { useEffect } from 'react';
-
 // Component
 import WeeklyCalorieChart from '../../components/Main/WeeklyCalorieChart';
 import TodayNutrition from '../../components/Main/TodayNutrition';
@@ -10,14 +8,10 @@ import { S_Footer } from '../../style/Footer.style';
 import { S_BottomTitle, S_Box } from './style';
 import { S_FlexBox } from '../../style/FlexBox.style';
 
-import { useAppSelector } from '../../_store/hooks';
-
 // HOC
 import Auth from '../../utils/auth';
 
 const Main = () => {
-  const date = useAppSelector(state => state.date.value);
-
   return (
     <div>
       <Header />
@@ -34,10 +28,10 @@ const Main = () => {
 
         <S_Box>
           {/* calendar */}
-          <CalendarContainer date={date} />
+          <CalendarContainer />
 
           {/* selected date's data */}
-          <OneDayListContainer date={date} />
+          <OneDayListContainer />
         </S_Box>
       </S_FlexBox>
       <S_Footer />


### PR DESCRIPTION
## refactor/date-to-store -> main✨

## 요약✏
- 선택한 날짜 데이터 각 컴포넌트에서 직접 리덕스 스토어 구독하여 가져오는 것으로 수정

## 구현 내용📝
- (수정 전)main 컴포넌트에서 리덕스 스토어에서 date 데이터 가져온 후 CalendarContainer, OneDayListContainer에 props로 넘겨줌 
-> (수정 후)두 컴포넌트에서 각각 리덕스 스토어에서 date 데이터 가져와서 사용

## Screenshots🎨

## 관련 이슈🎯
