### PR TITLE
[STYLE] 반응형 디자인 적용 및 디자인 디테일 수정

### DIFF
--- a/src/components/Home/style/index.ts
+++ b/src/components/Home/style/index.ts
@@ -26,14 +26,10 @@ export const S_H1 = styled.h1`
   margin-bottom: 40px;
 `;
 export const S_P = styled.p`
-<<<<<<< HEAD
-  font-size: 1.8rem;
-  text-align: center;
-=======
   font-size: 2.5rem;
   font-family: 'dongle';
+  text-align: center;
 
->>>>>>> c93a4fb4ddeb285428d974bbf25b935c0e3801c5
   padding: 30px;
   margin-bottom: 40px;
 `;

--- a/src/components/Home/style/index.ts
+++ b/src/components/Home/style/index.ts
@@ -26,6 +26,7 @@ export const S_H1 = styled.h1`
 `;
 export const S_P = styled.p`
   font-size: 1.8rem;
+  text-align: center;
   padding: 30px;
   margin-bottom: 40px;
 `;

--- a/src/components/Main/AdditionalInformationModal.tsx
+++ b/src/components/Main/AdditionalInformationModal.tsx
@@ -6,7 +6,7 @@ import {
   S_AdditionalInformationModalWrapper,
   S_Label,
   S_InputWrapper,
-  S_BlueBtn,
+  S_YellowBtn,
   S_RedBtn,
   S_Input,
   S_Gender,
@@ -97,7 +97,7 @@ const AdditionalInformationModal = (props: Props) => {
         {/* 요청 버튼들 / 디자인 변경 가능 */}
         <S_FlexBox width="100%" justifyContent="flex-end">
           <S_RedBtn onClick={onClickCloseModal}>취소</S_RedBtn>
-          <S_BlueBtn>전송하기</S_BlueBtn>
+          <S_YellowBtn>전송하기</S_YellowBtn>
         </S_FlexBox>
       </S_AdditionalInformationModalWrapper>
     </S_CenterBox>

--- a/src/components/Main/ImgUploadModal.tsx
+++ b/src/components/Main/ImgUploadModal.tsx
@@ -7,7 +7,7 @@ import {
   S_BlankImg,
   S_Img,
   S_ImgWrapper,
-  S_BlueBtn,
+  S_YellowBtn,
   S_SelectWrapper,
   S_Select,
 } from './style';
@@ -117,7 +117,7 @@ const ImgUploadModal = (props: Props) => {
 
         {/* 버튼 */}
         <S_BottomBtns>
-          <S_BlueBtn onClick={onClickUpload}>전송하기</S_BlueBtn>
+          <S_YellowBtn onClick={onClickUpload}>전송하기</S_YellowBtn>
         </S_BottomBtns>
       </S_FlexBox>
     </S_CenterBox>

--- a/src/components/Main/style/index.ts
+++ b/src/components/Main/style/index.ts
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 import { S_FlexBox } from '../../../style/FlexBox.style';
 import { S_Button } from '../../../style/Button.style';
+import { Color } from '../../../utils/color';
+import S_CenterBox from '../../../style/CenterBox.style';
 
 /**-------------types-------------**/
 interface InputProps {
@@ -17,9 +19,13 @@ export const S_RedBtn = styled(S_Btn)`
   background-color: red;
   margin-right: 5px;
 `;
-export const S_BlueBtn = styled(S_Btn)`
-  background-color: #119518;
+export const S_YellowBtn = styled(S_Btn)`
+  background-color: ${Color.mainColor};
+  color: black;
   border-radius: 5px;
+  :hover {
+    opacity: 0.9;
+  }
 `;
 export const S_Title = styled(S_FlexBox)<{ marginBottom?: string }>`
   width: 100%;

--- a/src/components/common/OneMealDetailModal.tsx
+++ b/src/components/common/OneMealDetailModal.tsx
@@ -42,7 +42,6 @@ const OneMealDetailModal = ({ show, onClickCloseModal, data }: Props) => {
         width="90%"
         height="90%"
       >
-        {' '}
         <S_CloseBtn onClick={onClickCloseModal}>✖︎</S_CloseBtn>
         <S_TimeWrapper>
           <p>{data.time}</p>

--- a/src/components/common/style/index.ts
+++ b/src/components/common/style/index.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { S_FlexBox } from '../../../style/FlexBox.style';
 import { S_Button } from '../../../style/Button.style';
+import { Color } from '../../../utils/color';
 
 /**-------------types-------------**/
 interface square {
@@ -19,7 +20,7 @@ export const S_HeaderWrapper = styled(S_FlexBox)`
   left: 0;
   right: 0;
   padding: 0 50px;
-  border-bottom: 0.5px solid rgba(0, 0, 0, 0.5);
+  border-bottom: ${Color.lineBorder};
   z-index: 10;
 
   background-color: white;

--- a/src/pages/Analysis/index.tsx
+++ b/src/pages/Analysis/index.tsx
@@ -50,11 +50,6 @@ const Analysis = () => {
     <div>
       {/* Header */}
       <Header />
-<<<<<<< HEAD
-      <S_FlexBox margin="64px 0 0 0">
-        <S_Box>
-          <S_ImgWrapper>
-=======
 
       {/* 말풍선 */}
       <S_CheckInform>
@@ -66,7 +61,6 @@ const Analysis = () => {
         <S_Box>
           <S_ImgWrapper>
             {/* <S_Time>아침</S_Time> */}
->>>>>>> c93a4fb4ddeb285428d974bbf25b935c0e3801c5
             <img src={imgUrl} />
           </S_ImgWrapper>
 

--- a/src/pages/Analysis/index.tsx
+++ b/src/pages/Analysis/index.tsx
@@ -49,16 +49,15 @@ const Analysis = () => {
   return (
     <div>
       <Header />
-      <S_CheckInform>
-        <span>칼로리 정보를 확인하고 수정해주세요!</span>
-      </S_CheckInform>
       <S_FlexBox margin="64px 0 0 0">
         <S_Box>
           <S_ImgWrapper>
-            {/*<S_Time>아침</S_Time>*/}
             <img src={imgUrl} />
           </S_ImgWrapper>
           <S_FlexBox flexDirection="column" width="300px" height="500px">
+            <S_CheckInform>
+              <span>칼로리 정보를 확인하고 수정해주세요!</span>
+            </S_CheckInform>
             <S_DetailWrapper>
               <p>{`오늘의 ${time}`}</p>
               <CalorieDetail />

--- a/src/pages/Analysis/style.ts
+++ b/src/pages/Analysis/style.ts
@@ -4,17 +4,12 @@ import { S_Button } from '../../style/Button.style';
 import { Color } from '../../utils/color';
 
 export const S_CheckInform = styled.div`
-<<<<<<< HEAD
-  position: relative;
-  top: -10px;
-=======
   font-family: 'dongle';
   font-size: 1.3rem;
 
-  position: absolute;
-  top: 65px;
-  right: 5%;
->>>>>>> c93a4fb4ddeb285428d974bbf25b935c0e3801c5
+  position: relative;
+  top: -10px;
+  right: -20%;
 
   padding: 10px;
   border-radius: 10px;
@@ -30,7 +25,7 @@ export const S_CheckInform = styled.div`
     content: '';
     position: absolute;
     bottom: -10px;
-    right: 50%;
+    right: 70%;
   }
 `;
 

--- a/src/pages/Analysis/style.ts
+++ b/src/pages/Analysis/style.ts
@@ -1,36 +1,39 @@
 import styled from 'styled-components';
 import { S_FlexBox } from '../../style/FlexBox.style';
 import { S_Button } from '../../style/Button.style';
+import { Color } from '../../utils/color';
 
 export const S_CheckInform = styled.div`
-  position: absolute;
-  top: 100px;
-  right: 5%;
+  position: relative;
+  top: -10px;
 
   padding: 10px;
   border-radius: 10px;
   text-align: center;
-  background: #fee365;
+  background: ${Color.mainColor};
   font-style: italic;
 
   :after {
-    border-top: 10px solid #fee365;
+    border-top: 10px solid ${Color.mainColor};
     border-left: 10px solid transparent;
     border-right: 10px solid transparent;
     border-bottom: 0px solid transparent;
     content: '';
     position: absolute;
     bottom: -10px;
-    right: 70%;
+    right: 50%;
   }
 `;
 
 export const S_ImgWrapper = styled(S_FlexBox)`
   flex-direction: column;
   width: 50%;
-  //border: 1px solid;
   filter: drop-shadow(0 0.3rem 0.4rem rgba(0, 0, 0, 0.5));
   & > img {
+    width: 100%;
+  }
+
+  @media screen and (max-width: 700px) {
     width: 100%;
   }
 `;
@@ -67,8 +70,8 @@ export const S_SendBtn = styled(S_Button)`
   width: 90%;
   height: 10%;
 
-  background-color: #99d156;
-  color: rgba(0, 0, 0, 0.8);
+  background-color: ${Color.mainColor};
+  color: black;
 
   font-weight: 500;
   font-size: large;
@@ -77,4 +80,8 @@ export const S_SendBtn = styled(S_Button)`
   border-radius: 10px;
   box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px,
     rgba(60, 64, 67, 0.15) 0px 1px 3px 1px;
+
+  :hover {
+    opacity: 0.9;
+  }
 `;

--- a/src/pages/Main/style.ts
+++ b/src/pages/Main/style.ts
@@ -1,10 +1,21 @@
 import styled from 'styled-components';
 import { S_FlexBox } from '../../style/FlexBox.style';
+import { Color } from '../../utils/color';
 
 export const S_Box = styled(S_FlexBox)`
   width: 90%;
   justify-content: space-evenly;
   margin: 5% 0;
+
+  @media screen and (max-width: 700px) {
+    flex-direction: column;
+  }
+  & > * {
+    @media screen and (max-width: 700px) {
+      width: 100%;
+      margin: 20px 0;
+    }
+  }
 `;
 
 export const S_BottomTitle = styled.p`
@@ -14,5 +25,5 @@ export const S_BottomTitle = styled.p`
   text-align: center;
 
   margin-top: 3%;
-  border-top: 1px solid; // 임시
+  border-top: ${Color.lineBorder};
 `;

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,4 +1,5 @@
 // color 작성
 export const Color = {
   mainColor: '#fee365',
+  lineBorder: '0.5px solid rgba(0, 0, 0, 0.5)',
 };


### PR DESCRIPTION
## ui-design -> main (Closes #)✨

## 요약✏
- 반응형 디자인 적용
- 디자인 디테일 수정

## 구현 내용📝
- 반응형 디자인 적용 (max-width 700px 기준으로 적용함 - 컴포넌트 겹치기 시작하는 시점)
- home 페이지 텍스트 중앙 정렬
- 구분선 디자인 통일
- 이미지 업로드 모달 버튼 & 이미지 분석 페이지 저장 버튼 디자인 통일

## Screenshots🎨
<img width="200px" src="https://user-images.githubusercontent.com/78535339/184911711-53fdb669-ce88-4810-b450-b8167b005d0f.gif" /> <img width="200px" src="https://user-images.githubusercontent.com/78535339/184911753-1f970a30-5eb0-40a6-8914-9c63a3471e47.gif" />

## 관련 이슈🎯
- 모달 크기 반응형 적용 안함
